### PR TITLE
drop ifdef SISMERGED

### DIFF
--- a/src/sis.h
+++ b/src/sis.h
@@ -138,14 +138,9 @@
 
 #define SISDUALHEAD		/* Include Dual Head code  */
 
-#define SISMERGED		/* Include Merged-FB code */
-
-#undef SISXINERAMA
-#ifdef SISMERGED
 #define SISXINERAMA		/* Include SiS Pseudo-Xinerama for MergedFB mode */
 #define SIS_XINERAMA_MAJOR_VERSION  1
 #define SIS_XINERAMA_MINOR_VERSION  1
-#endif
 
 #if defined(SIS_HAVE_EXA) || (defined(USE_EXA) && (USE_EXA != 0))
 #define SIS_USE_EXA		/* Include code for EXA */
@@ -1220,7 +1215,6 @@ typedef struct {
     ExtensionEntry	*SiSCtrlExtEntry;
     char		devsectname[32];
     Bool		SCLogQuiet;
-#ifdef SISMERGED
     Bool		MergedFB, MergedFBAuto;
     SiSScrn2Rel		CRT2Position;
     char		*CRT2HSync;
@@ -1250,7 +1244,6 @@ typedef struct {
     ExtensionEntry	*XineramaExtEntry;
     int			SiSXineramaVX, SiSXineramaVY;
     Bool		AtLeastOneNonClone;
-#endif
 #endif
 } SISRec, *SISPtr;
 
@@ -1329,7 +1322,6 @@ typedef struct _customttable {
     const char   *optionName;
 } customttable;
 
-#ifdef SISMERGED
 #ifdef SISXINERAMA
 typedef struct _SiSXineramaData {
     int x;
@@ -1337,7 +1329,6 @@ typedef struct _SiSXineramaData {
     int width;
     int height;
 } SiSXineramaData;
-#endif
 #endif
 
 extern const customttable SiS_customttable[];
@@ -1418,6 +1409,3 @@ extern unsigned char sis_pci_read_host_bridge_u8(int offset);
 extern void sis_pci_write_host_bridge_u8(int offset, unsigned char value);
 extern void sis_pci_write_host_bridge_u32(int offset, unsigned long value);
 #endif  /* _SIS_H_ */
-
-
-

--- a/src/sis_cursor.c
+++ b/src/sis_cursor.c
@@ -335,7 +335,6 @@ SiSSetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
     outSISREG(SISSR, sridx); outSISREG(SISCR, cridx);
 }
 
-#ifdef SISMERGED
 static void
 SiSSetCursorPositionMerged(ScrnInfoPtr pScrn1, int x, int y)
 {
@@ -406,7 +405,6 @@ SiSSetCursorPositionMerged(ScrnInfoPtr pScrn1, int x, int y)
        sis301SetCursorPositionY310(y2, y2_preset)
     }
 }
-#endif
 
 static void
 SiS300SetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
@@ -416,12 +414,10 @@ SiS300SetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
     UShort x_preset = 0;
     UShort y_preset = 0;
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        SiSSetCursorPositionMerged(pScrn, x, y);
        return;
     }
-#endif
 
     if(mode->Flags & V_INTERLACE)     y /= 2;
     else if(mode->Flags & V_DBLSCAN)  y *= 2;
@@ -467,12 +463,10 @@ SiS310SetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
     UShort x_preset = 0;
     UShort y_preset = 0;
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        SiSSetCursorPositionMerged(pScrn, x, y);
        return;
     }
-#endif
 
     if(mode->Flags & V_INTERLACE)     y >>= 1;
     else if(mode->Flags & V_DBLSCAN)  y <<= 1;
@@ -691,14 +685,11 @@ SiS300LoadCursorImage(ScrnInfoPtr pScrn, UChar *src)
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
 #endif
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        if((CDMPTR->CRT1->Flags & V_DBLSCAN) && (CDMPTR->CRT2->Flags & V_DBLSCAN)) {
           sizedouble = TRUE;
        }
-    } else
-#endif
-           if(pSiS->CurrentLayout.mode->Flags & V_DBLSCAN) {
+    } else if(pSiS->CurrentLayout.mode->Flags & V_DBLSCAN) {
        sizedouble = TRUE;
     }
 
@@ -787,14 +778,11 @@ SiS310LoadCursorImage(ScrnInfoPtr pScrn, UChar *src)
     }
 #endif
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        if((CDMPTR->CRT1->Flags & V_DBLSCAN) && (CDMPTR->CRT2->Flags & V_DBLSCAN)) {
           sizedouble = TRUE;
        }
-    } else
-#endif
-           if(pSiS->CurrentLayout.mode->Flags & V_DBLSCAN) {
+    } else if(pSiS->CurrentLayout.mode->Flags & V_DBLSCAN) {
        sizedouble = TRUE;
     }
 
@@ -917,14 +905,12 @@ SiS300UseHWCursor(ScreenPtr pScreen, CursorPtr pCurs)
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     SISPtr  pSiS = SISPTR(pScrn);
     DisplayModePtr  mode = pSiS->CurrentLayout.mode;
-#ifdef SISMERGED
     DisplayModePtr  mode2 = NULL;
 
     if(pSiS->MergedFB) {
        mode = CDMPTR->CRT1;
        mode2 = CDMPTR->CRT2;
     }
-#endif
 
     switch (pSiS->Chipset)  {
       case PCI_CHIP_SIS300:
@@ -934,14 +920,12 @@ SiS300UseHWCursor(ScreenPtr pScreen, CursorPtr pCurs)
 	    return FALSE;
 	 if((mode->Flags & V_DBLSCAN) && (pCurs->bits->height > 32))
 	    return FALSE;
-#ifdef SISMERGED
 	 if(pSiS->MergedFB) {
 	    if(mode2->Flags & V_INTERLACE)
 	       return FALSE;
 	    if((mode2->Flags & V_DBLSCAN) && (pCurs->bits->height > 32))
 	       return FALSE;
 	 }
-#endif
 	 break;
 
       case PCI_CHIP_SIS550:
@@ -964,14 +948,12 @@ SiS300UseHWCursor(ScreenPtr pScreen, CursorPtr pCurs)
 	    return FALSE;
 	 if((mode->Flags & V_DBLSCAN) && (pCurs->bits->height > 32))
 	    return FALSE;
-#ifdef SISMERGED
 	 if(pSiS->MergedFB) {
 	    if(mode2->Flags & V_INTERLACE)
 	       return FALSE;
 	    if((mode2->Flags & V_DBLSCAN) && (pCurs->bits->height > 32))
 	       return FALSE;
 	 }
-#endif
 	 break;
 
       default:
@@ -990,14 +972,12 @@ SiSUseHWCursorARGB(ScreenPtr pScreen, CursorPtr pCurs)
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     SISPtr  pSiS = SISPTR(pScrn);
     DisplayModePtr  mode = pSiS->CurrentLayout.mode;
-#ifdef SISMERGED
     DisplayModePtr  mode2 = NULL;
 
     if(pSiS->MergedFB) {
        mode = CDMPTR->CRT1;
        mode2 = CDMPTR->CRT2;
     }
-#endif
 
     switch (pSiS->Chipset)  {
       case PCI_CHIP_SIS300:
@@ -1009,14 +989,12 @@ SiSUseHWCursorARGB(ScreenPtr pScreen, CursorPtr pCurs)
 	    return FALSE;
 	 if((mode->Flags & V_DBLSCAN) && (pCurs->bits->height > 16))
 	    return FALSE;
-#ifdef SISMERGED
 	 if(pSiS->MergedFB) {
 	    if(mode2->Flags & V_INTERLACE)
 	       return FALSE;
 	    if((mode2->Flags & V_DBLSCAN) && (pCurs->bits->height > 16))
 	       return FALSE;
 	 }
-#endif
          break;
 
       case PCI_CHIP_SIS550:
@@ -1043,14 +1021,12 @@ SiSUseHWCursorARGB(ScreenPtr pScreen, CursorPtr pCurs)
 	    return FALSE;
 	 if((pSiS->CurrentLayout.bitsPerPixel == 8) && (pSiS->VBFlags & CRT2_ENABLE))
 	    return FALSE;
-#ifdef SISMERGED
 	 if(pSiS->MergedFB) {
 	    if(mode2->Flags & V_INTERLACE)
 	       return FALSE;
 	    if((mode->Flags & V_DBLSCAN) && (pCurs->bits->height > 32))
 	       return FALSE;
 	 }
-#endif
 	 break;
 
       default:
@@ -1076,14 +1052,11 @@ SiS300LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
 #endif
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        if((CDMPTR->CRT1->Flags & V_DBLSCAN) && (CDMPTR->CRT2->Flags & V_DBLSCAN)) {
           sizedouble = TRUE;
        }
-    } else
-#endif
-           if(pSiS->CurrentLayout.mode->Flags & V_DBLSCAN) {
+    } else if(pSiS->CurrentLayout.mode->Flags & V_DBLSCAN) {
        sizedouble = TRUE;
     }
 
@@ -1207,14 +1180,11 @@ static void SiS310LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
 #endif
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        if((CDMPTR->CRT1->Flags & V_DBLSCAN) && (CDMPTR->CRT2->Flags & V_DBLSCAN)) {
           sizedouble = TRUE;
        }
-    } else
-#endif
-           if(pSiS->CurrentLayout.mode->Flags & V_DBLSCAN) {
+    } else if(pSiS->CurrentLayout.mode->Flags & V_DBLSCAN) {
        sizedouble = TRUE;
     }
 

--- a/src/sis_dac.c
+++ b/src/sis_dac.c
@@ -1551,12 +1551,10 @@ int SiSMemBandWidth(ScrnInfoPtr pScrn, Bool IsForCRT2)
 		       if(pSiS->SecondHead) GetForCRT1 = TRUE;
 		    }
 #endif
-#ifdef SISMERGED
 		    if(pSiS->MergedFB && IsForCRT2) {
 		       DHM = TRUE;
 		       GetForCRT1 = FALSE;
 		    }
-#endif
 
 		    if(DHM) {
 

--- a/src/sis_dga.c
+++ b/src/sis_dga.c
@@ -106,7 +106,6 @@ SISSetupDGAMode(
 
    while(pMode) {
 
-#ifdef SISMERGED
 	if(pSiS->MergedFB) {
 	   Bool nogood = FALSE;
 	   /* Filter out all meta modes that would require driver-side panning */
@@ -144,7 +143,6 @@ SISSetupDGAMode(
 	      goto mode_nogood;
 	   }
 	}
-#endif
 
 	otherPitch = secondPitch ? secondPitch : pMode->HDisplay;
 
@@ -232,9 +230,7 @@ SECOND_PASS:
 					     currentMode->viewportHeight);
 	}
 
-#ifdef SISMERGED
 mode_nogood:
-#endif
 
 	pMode = pMode->next;
 	if(pMode == firstMode)
@@ -259,17 +255,13 @@ SISDGAInit(ScreenPtr pScreen)
 #ifdef SISDUALHEAD
    if(!pSiS->DualHeadMode) {
 #endif
-#ifdef SISMERGED
       if(!(pSiS->MergedFB)) {
-#endif
          modes = SISSetupDGAMode(pScrn, modes, &num, 8, 8,
 				 (pScrn->bitsPerPixel == 8),
 				 ((pScrn->bitsPerPixel != 8)
 				     ? 0 : pScrn->displayWidth),
 				 0, 0, 0, PseudoColor);
-#ifdef SISMERGED
       }
-#endif
 #ifdef SISDUALHEAD
    }
 #endif

--- a/src/sis_driver.h
+++ b/src/sis_driver.h
@@ -1583,10 +1583,8 @@ UShort         SiS_CheckModeCRT1(ScrnInfoPtr pScrn, DisplayModePtr mode,
 UShort         SiS_CheckModeCRT2(ScrnInfoPtr pScrn, DisplayModePtr mode,
 				 unsigned int VBFlags, Bool hcm);
 
-#ifdef SISMERGED
 static Bool    InRegion(int x, int y, region r);
 static void    SISMergedPointerMoved(SCRN_ARG_TYPE arg, int x, int y);
-#endif
 Bool           SiSBridgeIsInSlaveMode(ScrnInfoPtr pScrn);
 UShort	       SiS_GetModeNumber(ScrnInfoPtr pScrn, DisplayModePtr mode, unsigned int VBFlags);
 UChar  	       SiS_GetSetBIOSScratch(ScrnInfoPtr pScrn, UShort offset, UChar value);

--- a/src/sis_opt.c
+++ b/src/sis_opt.c
@@ -267,7 +267,6 @@ static const OptionInfoRec SISOptions[] = {
     { OPTION_ENABLEHOTKEY,		"EnableHotkey",	   		OPTV_BOOLEAN,	{0}, FALSE },
     { OPTION_FORCE1ASPECT,		"ForceCRT1VGAAspect",		OPTV_STRING,	{0}, FALSE },
     { OPTION_FORCE2ASPECT,		"ForceCRT2VGAAspect",		OPTV_STRING,	{0}, FALSE },
-#ifdef SISMERGED
     { OPTION_MERGEDFB,			"MergedFB",			OPTV_ANYSTR,	{0}, FALSE },
     { OPTION_MERGEDFB,			"TwinView",			OPTV_ANYSTR,	{0}, FALSE },	/* alias */
     { OPTION_MERGEDFBAUTO,		"MergedFBAuto",			OPTV_BOOLEAN,	{0}, FALSE },
@@ -285,7 +284,6 @@ static const OptionInfoRec SISOptions[] = {
     { OPTION_CRT2ISSCRN0,		"MergedXineramaCRT2IsScreen0",	OPTV_BOOLEAN,	{0}, FALSE },
     { OPTION_MERGEDFBNONRECT,		"MergedNonRectangular",		OPTV_BOOLEAN,	{0}, FALSE },
     { OPTION_MERGEDFBMOUSER,		"MergedMouseRestriction",	OPTV_BOOLEAN,	{0}, FALSE },
-#endif
 #endif
     { -1,				NULL,				OPTV_NONE,	{0}, FALSE }
 };
@@ -566,7 +564,6 @@ SiSOptions(ScrnInfoPtr pScrn)
 #ifndef SISCHECKOSSSE
     pSiS->XvSSEMemcpy = FALSE;
 #endif
-#ifdef SISMERGED
     pSiS->MergedFB = pSiS->MergedFBAuto = FALSE;
     pSiS->CRT2Position = sisRightOf;
     pSiS->CRT2HSync = NULL;
@@ -580,7 +577,6 @@ SiSOptions(ScrnInfoPtr pScrn)
 #ifdef SISXINERAMA
     pSiS->UseSiSXinerama = TRUE;
     pSiS->CRT2IsScrn0 = FALSE;
-#endif
 #endif
 
     /* Chipset dependent defaults */
@@ -789,7 +785,6 @@ SiSOptions(ScrnInfoPtr pScrn)
     /* MergedFB
      * Enable/disable and configure merged framebuffer mode
      */
-#ifdef SISMERGED
 #ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(xf86IsOptionSet(pSiS->Options, OPTION_MERGEDFB)) {
@@ -924,7 +919,6 @@ SiSOptions(ScrnInfoPtr pScrn)
 #endif
        }
     }
-#endif
 
     /* Some options can only be specified in the Master Head's Device
      * section. Here we give the user a hint in the log.
@@ -1859,13 +1853,11 @@ SiSOptions(ScrnInfoPtr pScrn)
     /* ShadowFB */
     from = X_DEFAULT;
     if(xf86GetOptValBool(pSiS->Options, OPTION_SHADOW_FB, &pSiS->ShadowFB)) {
-#ifdef SISMERGED
        if(pSiS->MergedFB) {
 	  pSiS->ShadowFB = FALSE;
 	  xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
 	      "Shadow Framebuffer not supported in MergedFB mode\n");
        } else
-#endif
 	  from = X_CONFIG;
     }
     if(pSiS->ShadowFB) {
@@ -1876,12 +1868,10 @@ SiSOptions(ScrnInfoPtr pScrn)
 
     /* Rotate */
     if((strptr = (char *)xf86GetOptValString(pSiS->Options, OPTION_ROTATE))) {
-#ifdef SISMERGED
        if(pSiS->MergedFB) {
 	  xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
 	      "Screen rotation not supported in MergedFB mode\n");
        } else
-#endif
        if(IsDHM) {
 	  xf86DrvMsg(pScrn->scrnIndex, X_WARNING, baddhm,
 	     pSiS->Options[SiS_FIFT(pSiS->Options, OPTION_ROTATE)].name);
@@ -1908,12 +1898,10 @@ SiSOptions(ScrnInfoPtr pScrn)
 
     /* Reflect */
     if((strptr = (char *)xf86GetOptValString(pSiS->Options, OPTION_REFLECT))) {
-#ifdef SISMERGED
        if(pSiS->MergedFB) {
 	  xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
 	      "Screen reflection not supported in MergedFB mode\n");
        } else
-#endif
        if(IsDHM) {
 	  xf86DrvMsg(pScrn->scrnIndex, X_WARNING, baddhm,
 	     pSiS->Options[SiS_FIFT(pSiS->Options, OPTION_REFLECT)].name);

--- a/src/sis_utility.c
+++ b/src/sis_utility.c
@@ -325,7 +325,6 @@ SISSwitchCRT1Status(ScrnInfoPtr pScrn, int onoff, Bool quiet)
        }
     }
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        if(((SiSMergedDisplayModePtr)mode->Private)->CRT2Position != sisClone) {
           if(!onoff) {
@@ -350,7 +349,6 @@ SISSwitchCRT1Status(ScrnInfoPtr pScrn, int onoff, Bool quiet)
 	  mode = ((SiSMergedDisplayModePtr)mode->Private)->CRT1;
        }
     }
-#endif
 
     vbflags &= ~(DISPTYPE_CRT1 | SINGLE_MODE | MIRROR_MODE | CRT1_LCDA);
     vbflags3 &= ~(VB3_CRT1_TV | VB3_CRT1_LCD | VB3_CRT1_VGA);
@@ -486,7 +484,6 @@ SISSwitchCRT2Type(ScrnInfoPtr pScrn, ULong newvbflags, Bool quiet)
        newvbflags &= ~TV_YPBPR;
     }
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        if((mode->Private) &&
           ((SiSMergedDisplayModePtr)mode->Private)->CRT2Position != sisClone) {
@@ -512,7 +509,6 @@ SISSwitchCRT2Type(ScrnInfoPtr pScrn, ULong newvbflags, Bool quiet)
 	  mode = ((SiSMergedDisplayModePtr)mode->Private)->CRT2;
        }
     }
-#endif
 
     if((!(newvbflags & CRT2_ENABLE)) && (!(newvbflags & DISPTYPE_CRT1))) {
        if(!quiet) {
@@ -627,14 +623,12 @@ SISCheckModeForCRT2Type(ScrnInfoPtr pScrn, DisplayModePtr mode, ULong vbflags, U
 
        if(vbflags & CRT2_ENABLE) {
 
-#ifdef SISMERGED
           if(pSiS->MergedFB) {
              hcm = pSiS->HaveCustomModes2;
              if(mode->Private) {
 	        mode = ((SiSMergedDisplayModePtr)mode->Private)->CRT2;
              }
           }
-#endif
 
           /* For RandR */
           if((mode->HDisplay > pScrn->virtualX) || (mode->VDisplay > pScrn->virtualY)) {
@@ -668,14 +662,12 @@ SISCheckModeForCRT2Type(ScrnInfoPtr pScrn, DisplayModePtr mode, ULong vbflags, U
 
        if(vbflags & CRT1_LCDA) {
 
-#ifdef SISMERGED
           if(pSiS->MergedFB) {
              hcm = pSiS->HaveCustomModes;
              if(mode->Private) {
 	        mode = ((SiSMergedDisplayModePtr)mode->Private)->CRT1;
 	     }
           }
-#endif
 
 	  /* For RandR */
 	  if((mode->HDisplay > pScrn->virtualX) || (mode->VDisplay > pScrn->virtualY)) {
@@ -762,7 +754,6 @@ SISCheckModeTimingForCRT2Type(ScrnInfoPtr pScrn, UShort cond, UShort hdisplay,
     return(SISCheckModeForCRT2Type(pScrn, mode, vbflags, cond, quiet));
 }
 
-#ifdef SISMERGED
 static void
 SISGetMergedModeDetails(ScrnInfoPtr pScrn,
 	   int hd, int vd, int ht, int vt, int hss, int hse, int vss, int vse, int clk,
@@ -803,7 +794,6 @@ SISGetMergedModeDetails(ScrnInfoPtr pScrn,
     *crt2y = tmode->VDisplay;
     *crt2clk = (unsigned int)SiSCalcVRate(tmode);
 }
-#endif
 
 /***********************************
  *   SiSCtrl extension interface   *
@@ -1505,7 +1495,6 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
       break;
 
    case SDC_CMD_GETMERGEDMODEDETAILS:
-#ifdef SISMERGED
       if(pSiS->MergedFB) {
          int clk, hd, hss, hse, ht, vd, vss, vse, vt;
 	 unsigned int pos, crt1x, crt1y, crt1clk, crt2x, crt2y, crt2clk;
@@ -1541,7 +1530,6 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 	 }
 
       } else
-#endif
          sdcbuf->sdc_result_header = SDC_RESULT_INVAL;
       break;
 

--- a/src/sis_vb.c
+++ b/src/sis_vb.c
@@ -248,13 +248,11 @@ void SISCRT1PreInit(ScrnInfoPtr pScrn)
     }
 #endif
 
-#ifdef SISMERGED
     if((pSiS->MergedFB) && (!(pSiS->MergedFBAuto))) {
        pSiS->CRT1Detected = TRUE;
        pSiS->CRT1off = 0;
        return;
     }
-#endif
 
     inSISIDXREG(SISCR, 0x32, CR32);
 

--- a/src/sis_vga.c
+++ b/src/sis_vga.c
@@ -851,11 +851,9 @@ SIS300Init(ScrnInfoPtr pScrn, DisplayModePtr mode)
 	pScrn->virtualX, pSiS->CurrentLayout.bitsPerPixel,
 	pScrn->virtualX * pSiS->CurrentLayout.bitsPerPixel/8);
 
-#ifdef SISMERGED
     if(pSiS->MergedFB) {
        realmode = ((SiSMergedDisplayModePtr)mode->Private)->CRT1;
     }
-#endif
 
     /* Copy current register settings to structure */
     (*pSiS->SiSSave)(pScrn, pReg);

--- a/src/sis_video.c
+++ b/src/sis_video.c
@@ -592,9 +592,7 @@ SISResetVideo(ScrnInfoPtr pScrn)
     }
 
     pPriv->mustresettap = TRUE;
-#ifdef SISMERGED
     pPriv->mustresettap2 = TRUE;
-#endif
 }
 
 /*********************************
@@ -810,11 +808,9 @@ set_maxencoding(SISPtr pSiS, SISPortPrivPtr pPriv)
 	     DummyEncoding.width = half;
           } else
 #endif
-#ifdef SISMERGED
           if(pSiS->MergedFB) {
 	     DummyEncoding.width = half;
           } else
-#endif
           if(pPriv->displayMode == DISPMODE_MIRROR) {
 	     DummyEncoding.width = half;
           }
@@ -1441,7 +1437,6 @@ calc_scale_factor(SISOverlayPtr pOverlay, ScrnInfoPtr pScrn,
   }
 }
 
-#ifdef SISMERGED
 static void
 calc_scale_factor_2(SISOverlayPtr pOverlay, ScrnInfoPtr pScrn,
                  SISPortPrivPtr pPriv, int index, int iscrt2)
@@ -1598,7 +1593,6 @@ calc_scale_factor_2(SISOverlayPtr pOverlay, ScrnInfoPtr pScrn,
      }
   }
 }
-#endif
 
 /*********************************
  *    Handle 4-tap scaler (340)  *
@@ -1793,7 +1787,6 @@ calc_line_buf_size_1(SISOverlayPtr pOverlay, SISPortPrivPtr pPriv)
 	calc_line_buf_size(pOverlay->srcW, pOverlay->wHPre, pOverlay->planar, pPriv);
 }
 
-#ifdef SISMERGED
 static __inline void
 calc_line_buf_size_2(SISOverlayPtr pOverlay, SISPortPrivPtr pPriv)
 {
@@ -1848,7 +1841,6 @@ merge_line_buf_mfb(SISPtr pSiS, SISPortPrivPtr pPriv, Bool enable1, Bool enable2
 
     }
 }
-#endif
 
 /* About linebuffer merging:
  *
@@ -2162,7 +2154,6 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
     CARD32 PSY;
     int    modeflags, totalPixels, confactor, sample, watchdog = 0;
 
-#ifdef SISMERGED
     if(pSiS->MergedFB && iscrt2) {
        screenX = pOverlay->currentmode2->HDisplay;
        screenY = pOverlay->currentmode2->VDisplay;
@@ -2173,7 +2164,6 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
        right = pOverlay->dstBox2.x2;
        pitch = pOverlay->pitch2 >> pPriv->shiftValue;
     } else {
-#endif
        screenX = pOverlay->currentmode->HDisplay;
        screenY = pOverlay->currentmode->VDisplay;
        modeflags = pOverlay->currentmode->Flags;
@@ -2182,9 +2172,7 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
        left = pOverlay->dstBox.x1;
        right = pOverlay->dstBox.x2;
        pitch = pOverlay->pitch >> pPriv->shiftValue;
-#ifdef SISMERGED
     }
-#endif
 
     if(bottom > screenY) bottom = screenY;
     if(right  > screenX) right  = screenX;
@@ -2218,21 +2206,17 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
     v_over = (((top >> 8) & 0x0f) | ((bottom >> 4) & 0xf0));
 
     /* set line buffer size */
-#ifdef SISMERGED
     if(pSiS->MergedFB && iscrt2) {
        setvideoreg(pSiS, Index_VI_Line_Buffer_Size, (CARD8)pOverlay->lineBufSize2);
        if(pPriv->is340 || pPriv->is761 || pPriv->isXGI) {
           setvideoreg(pSiS, Index_VI_Line_Buffer_Size_High, (CARD8)(pOverlay->lineBufSize2 >> 8));
        }
     } else {
-#endif
        setvideoreg(pSiS, Index_VI_Line_Buffer_Size, (CARD8)pOverlay->lineBufSize);
        if(pPriv->is340 || pPriv->is761 || pPriv->isXGI) {
           setvideoreg(pSiS, Index_VI_Line_Buffer_Size_High, (CARD8)(pOverlay->lineBufSize >> 8));
        }
-#ifdef SISMERGED
     }
-#endif
 
     /* set color key mode */
     setvideoregmask(pSiS, Index_VI_Key_Overlay_OP, pOverlay->keyOP, 0x0f);
@@ -2285,11 +2269,9 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
     setvideoregmask(pSiS, Index_VI_Disp_Y_UV_Buf_Pitch_Middle, (CARD8)(pitch >> 8), 0x0f);
 
     /* Set Y start address */
-#ifdef SISMERGED
     if(pSiS->MergedFB && iscrt2) {
        PSY = pOverlay->PSY2;
     } else
-#endif
        PSY = pOverlay->PSY;
 
     setvideoreg(pSiS, Index_VI_Disp_Y_Buf_Start_Low,    (CARD8)(PSY));
@@ -2308,12 +2290,10 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
 	CARD32  PSU = pOverlay->PSU;
 	CARD32  PSV = pOverlay->PSV;
 
-#ifdef SISMERGED
 	if(pSiS->MergedFB && iscrt2) {
 	   PSU = pOverlay->PSU2;
 	   PSV = pOverlay->PSV2;
 	}
-#endif
 
 	if(pOverlay->planar_shiftpitch) pitch >>= 1;
 
@@ -2348,7 +2328,6 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
     setvideoregmask(pSiS, Index_VI_Control_Misc1, 0x00, 0x20);
 
     /* Set scale factor */
-#ifdef SISMERGED
     if(pSiS->MergedFB && iscrt2) {
        setvideoreg(pSiS, Index_VI_Hor_Post_Up_Scale_Low, (CARD8)(pOverlay->HUSF2));
        setvideoreg(pSiS, Index_VI_Hor_Post_Up_Scale_High,(CARD8)((pOverlay->HUSF2) >> 8));
@@ -2366,7 +2345,6 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
 	  }
        }
     } else {
-#endif
        setvideoreg(pSiS, Index_VI_Hor_Post_Up_Scale_Low, (CARD8)(pOverlay->HUSF));
        setvideoreg(pSiS, Index_VI_Hor_Post_Up_Scale_High,(CARD8)((pOverlay->HUSF) >> 8));
        setvideoreg(pSiS, Index_VI_Ver_Up_Scale_Low,      (CARD8)(pOverlay->VUSF));
@@ -2381,10 +2359,7 @@ set_overlay(SISPtr pSiS, SISOverlayPtr pOverlay, SISPortPrivPtr pPriv, int index
 	     pPriv->mustresettap = FALSE;
 	  }
        }
-#ifdef SISMERGED
     }
-#endif
-
 }
 
 /*********************************
@@ -2402,9 +2377,7 @@ close_overlay(SISPtr pSiS, SISPortPrivPtr pPriv)
   pPriv->overlayStatus = FALSE;
 
   pPriv->mustresettap = TRUE;
-#ifdef SISMERGED
   pPriv->mustresettap2 = TRUE;
-#endif
 
   if(pPriv->displayMode & (DISPMODE_MIRROR | DISPMODE_SINGLE2)) {
 
@@ -2495,12 +2468,10 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
    int    srcOffsetX = 0, srcOffsetY = 0;
    int    sx = 0, sy = 0, watchdog;
    int    index = 0, iscrt2 = 0;
-#ifdef SISMERGED
    UChar  temp;
    UShort screen2width = 0;
    int    srcOffsetX2 = 0, srcOffsetY2 = 0;
    int    sx2 = 0, sy2 = 0;
-#endif
 
    /* Determine whether we have two overlays or only one */
    set_hastwooverlays(pSiS, pPriv);
@@ -2534,9 +2505,7 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
    set_dispmode(pScrn, pPriv);
 
    /* Check if overlay is supported with current mode */
-#ifdef SISMERGED
    if(!pSiS->MergedFB) {
-#endif
       if( ((pPriv->displayMode & DISPMODE_MIRROR) &&
            ((pSiS->MiscFlags & (MISC_CRT1OVERLAY|MISC_CRT2OVERLAY)) != (MISC_CRT1OVERLAY|MISC_CRT2OVERLAY))) ||
 	  ((pPriv->displayMode & DISPMODE_SINGLE1) &&
@@ -2549,9 +2518,7 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	 pPriv->NoOverlay = TRUE;
 	 return;
       }
-#ifdef SISMERGED
    }
-#endif
 
    memset(&overlay, 0, sizeof(overlay));
 
@@ -2565,7 +2532,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 
    overlay.bobEnable = 0x00;    /* Disable BOB de-interlacer */
 
-#ifdef SISMERGED
    if(pSiS->MergedFB) {
       overlay.DoFirst = TRUE;
       overlay.DoSecond = TRUE;
@@ -2585,7 +2551,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
       overlay.dstBox2.y1 = pPriv->drw_y - pSiS->CRT2pScrn->frameY0;
       overlay.dstBox2.y2 = overlay.dstBox2.y1 + pPriv->drw_h;
    } else {
-#endif
       overlay.currentmode = pSiS->CurrentLayout.mode;
       overlay.SCREENheight = overlay.currentmode->VDisplay;
       screenwidth = overlay.currentmode->HDisplay;
@@ -2593,38 +2558,32 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
       overlay.dstBox.x2 = pPriv->drw_x + pPriv->drw_w - pScrn->frameX0;
       overlay.dstBox.y1 = pPriv->drw_y - pScrn->frameY0;
       overlay.dstBox.y2 = pPriv->drw_y + pPriv->drw_h - pScrn->frameY0;
-#ifdef SISMERGED
    }
-#endif
 
    /* Note: x2/y2 is actually real coordinate + 1 */
 
    if((overlay.dstBox.x1 >= overlay.dstBox.x2) ||
       (overlay.dstBox.y1 >= overlay.dstBox.y2)) {
-#ifdef SISMERGED
-      if(pSiS->MergedFB) overlay.DoFirst = FALSE;
+      if(pSiS->MergedFB)
+           overlay.DoFirst = FALSE;
       else
-#endif
            return;
    }
 
    if((overlay.dstBox.x2 <= 0) || (overlay.dstBox.y2 <= 0)) {
-#ifdef SISMERGED
-      if(pSiS->MergedFB) overlay.DoFirst = FALSE;
+      if(pSiS->MergedFB)
+           overlay.DoFirst = FALSE;
       else
-#endif
            return;
    }
 
    if((overlay.dstBox.x1 >= screenwidth) || (overlay.dstBox.y1 >= overlay.SCREENheight)) {
-#ifdef SISMERGED
-      if(pSiS->MergedFB) overlay.DoFirst = FALSE;
+      if(pSiS->MergedFB)
+          overlay.DoFirst = FALSE;
       else
-#endif
-           return;
+          return;
    }
 
-#ifdef SISMERGED
    if(pSiS->MergedFB) {
       /* Check if dotclock is within limits for CRT1 */
       if(pPriv->displayMode & (DISPMODE_SINGLE1 | DISPMODE_MIRROR)) {
@@ -2633,7 +2592,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
          }
       }
    }
-#endif
 
    if(overlay.dstBox.x1 < 0) {
       srcOffsetX = pPriv->src_w * (-overlay.dstBox.x1) / pPriv->drw_w;
@@ -2647,14 +2605,12 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
    if((overlay.dstBox.x1 >= overlay.dstBox.x2 - 2) ||
       (overlay.dstBox.x1 >= screenwidth - 2)       ||
       (overlay.dstBox.y1 >= overlay.dstBox.y2)) {
-#ifdef SISMERGED
-      if(pSiS->MergedFB) overlay.DoFirst = FALSE;
+      if(pSiS->MergedFB)
+           overlay.DoFirst = FALSE;
       else
-#endif
            return;
    }
 
-#ifdef SISMERGED
    if(pSiS->MergedFB) {
       if((overlay.dstBox2.x2 <= 0) || (overlay.dstBox2.y2 <= 0))
 	 overlay.DoSecond = FALSE;
@@ -2725,16 +2681,13 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
          return;
       }
    }
-#endif
 
    switch(pPriv->id) {
 
      case PIXEL_FMT_YV12:
        overlay.planar = 1;
        overlay.planar_shiftpitch = 1;
-#ifdef SISMERGED
        if((!pSiS->MergedFB) || (overlay.DoFirst)) {
-#endif
           sx = (pPriv->src_x + srcOffsetX) & ~7;
           sy = (pPriv->src_y + srcOffsetY) & ~1;
           overlay.PSY = pPriv->bufAddr[pPriv->currentBuf] + sx + sy*srcPitch;
@@ -2746,7 +2699,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
           overlay.PSY >>= pPriv->shiftValue;
           overlay.PSV >>= pPriv->shiftValue;
           overlay.PSU >>= pPriv->shiftValue;
-#ifdef SISMERGED
        }
        if((pSiS->MergedFB) && (overlay.DoSecond)) {
           sx2 = (pPriv->src_x + srcOffsetX2) & ~7;
@@ -2761,15 +2713,12 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
           overlay.PSV2 >>= pPriv->shiftValue;
           overlay.PSU2 >>= pPriv->shiftValue;
        }
-#endif
        break;
 
      case PIXEL_FMT_I420:
        overlay.planar = 1;
        overlay.planar_shiftpitch = 1;
-#ifdef SISMERGED
        if((!pSiS->MergedFB) || (overlay.DoFirst)) {
-#endif
           sx = (pPriv->src_x + srcOffsetX) & ~7;
           sy = (pPriv->src_y + srcOffsetY) & ~1;
           overlay.PSY = pPriv->bufAddr[pPriv->currentBuf] + sx + sy*srcPitch;
@@ -2781,7 +2730,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
           overlay.PSY >>= pPriv->shiftValue;
           overlay.PSV >>= pPriv->shiftValue;
           overlay.PSU >>= pPriv->shiftValue;
-#ifdef SISMERGED
        }
        if((pSiS->MergedFB) && (overlay.DoSecond)) {
           sx2 = (pPriv->src_x + srcOffsetX2) & ~7;
@@ -2796,16 +2744,13 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
           overlay.PSV2 >>= pPriv->shiftValue;
           overlay.PSU2 >>= pPriv->shiftValue;
        }
-#endif
        break;
 
      case PIXEL_FMT_NV12:
      case PIXEL_FMT_NV21:
        overlay.planar = 1;
        overlay.planar_shiftpitch = 0;
-#ifdef SISMERGED
        if((!pSiS->MergedFB) || (overlay.DoFirst)) {
-#endif
           sx = (pPriv->src_x + srcOffsetX) & ~7;
           sy = (pPriv->src_y + srcOffsetY) & ~1;
           overlay.PSY = pPriv->bufAddr[pPriv->currentBuf] + sx + sy*srcPitch;
@@ -2815,7 +2760,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
           overlay.PSY >>= pPriv->shiftValue;
           overlay.PSV >>= pPriv->shiftValue;
           overlay.PSU = overlay.PSV;
-#ifdef SISMERGED
        }
        if((pSiS->MergedFB) && (overlay.DoSecond)) {
           sx2 = (pPriv->src_x + srcOffsetX2) & ~7;
@@ -2828,7 +2772,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
           overlay.PSV2 >>= pPriv->shiftValue;
           overlay.PSU2 = overlay.PSV2;
        }
-#endif
        break;
 
      case PIXEL_FMT_YUY2:
@@ -2838,15 +2781,12 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
      case PIXEL_FMT_RGB5:
      default:
        overlay.planar = 0;
-#ifdef SISMERGED
        if((!pSiS->MergedFB) || (overlay.DoFirst)) {
-#endif
           sx = (pPriv->src_x + srcOffsetX) & ~1;
           sy = (pPriv->src_y + srcOffsetY);
           overlay.PSY = (pPriv->bufAddr[pPriv->currentBuf] + sx*2 + sy*srcPitch);
           overlay.PSY += FBOFFSET;
           overlay.PSY >>= pPriv->shiftValue;
-#ifdef SISMERGED
        }
        if((pSiS->MergedFB) && (overlay.DoSecond)) {
           sx2 = (pPriv->src_x + srcOffsetX2) & ~1;
@@ -2855,14 +2795,11 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
           overlay.PSY2 += FBOFFSET;
           overlay.PSY2 >>= pPriv->shiftValue;
        }
-#endif
        break;
    }
 
    /* Some clipping checks */
-#ifdef SISMERGED
    if((!pSiS->MergedFB) || (overlay.DoFirst)) {
-#endif
       overlay.srcW = pPriv->src_w - (sx - pPriv->src_x);
       overlay.srcH = pPriv->src_h - (sy - pPriv->src_y);
       if( (pPriv->oldx1 != overlay.dstBox.x1) ||
@@ -2873,7 +2810,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	 pPriv->oldx1 = overlay.dstBox.x1; pPriv->oldx2 = overlay.dstBox.x2;
 	 pPriv->oldy1 = overlay.dstBox.y1; pPriv->oldy2 = overlay.dstBox.y2;
       }
-#ifdef SISMERGED
    }
    if((pSiS->MergedFB) && (overlay.DoSecond)) {
       overlay.srcW2 = pPriv->src_w - (sx2 - pPriv->src_x);
@@ -2887,9 +2823,7 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	 pPriv->oldy1_2 = overlay.dstBox2.y1; pPriv->oldy2_2 = overlay.dstBox2.y2;
       }
    }
-#endif
 
-#ifdef SISMERGED
    /* Disable an overlay if it is not to be displayed (but enabled currently) */
    if((pSiS->MergedFB) && (pPriv->hasTwoOverlays)) {
       if(!overlay.DoFirst) {
@@ -2916,7 +2850,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	 }
       }
    }
-#endif
 
    /* Loop head */
    /* Note: index can only be 1 for CRT2, ie overlay 1
@@ -2936,7 +2869,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	 index = 0; iscrt2 = 1;
       }
       overlay.VBlankActiveFunc = vblank_active_CRT2;
-#ifdef SISMERGED
       if(!pPriv->hasTwoOverlays) {
 	 if((pSiS->MergedFB) && (!overlay.DoSecond)) {
 	    index = 0; iscrt2 = 0;
@@ -2944,11 +2876,9 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	    pPriv->displayMode = DISPMODE_SINGLE1;
 	 }
       }
-#endif
    } else {
       index = 0; iscrt2 = 0;
       overlay.VBlankActiveFunc = vblank_active_CRT1;
-#ifdef SISMERGED
       if((pSiS->MergedFB) && (!overlay.DoFirst)) {
 	 if(pPriv->hasTwoOverlays) index = 1;
 	 iscrt2 = 1;
@@ -2957,19 +2887,15 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	    pPriv->displayMode = DISPMODE_SINGLE2;
 	 }
       }
-#endif
    }
 
    /* set display mode SR06,32 (CRT1, CRT2 or mirror) */
    set_disptype_regs(pScrn, pPriv);
 
    /* set (not only calc) merge line buffer */
-#ifdef SISMERGED
    if(!pSiS->MergedFB) {
-#endif
       merge_line_buf(pSiS, pPriv, (overlay.srcW > pPriv->linebufMergeLimit), overlay.srcW,
       		     pPriv->linebufMergeLimit);
-#ifdef SISMERGED
    } else {
       Bool temp1 = FALSE, temp2 = FALSE;
       if(overlay.DoFirst) {
@@ -2981,17 +2907,12 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
       merge_line_buf_mfb(pSiS, pPriv, temp1, temp2, overlay.srcW, overlay.srcW2,
 			 pPriv->linebufMergeLimit);
    }
-#endif
 
    /* calculate (not set!) line buffer length */
-#ifdef SISMERGED
    if((!pSiS->MergedFB) || (overlay.DoFirst))
-#endif
       calc_line_buf_size_1(&overlay, pPriv);
-#ifdef SISMERGED
    if((pSiS->MergedFB) && (overlay.DoSecond))
       calc_line_buf_size_2(&overlay, pPriv);
-#endif
 
    if(pPriv->dualHeadMode) {
 #ifdef SISDUALHEAD
@@ -3031,11 +2952,9 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 MIRROR:
 
    /* calculate scale factor */
-#ifdef SISMERGED
    if(pSiS->MergedFB && iscrt2)
       calc_scale_factor_2(&overlay, pScrn, pPriv, index, iscrt2);
    else
-#endif
       calc_scale_factor(&overlay, pScrn, pPriv, index, iscrt2);
 
    /* Select overlay 0 (used for CRT1/or CRT2) or overlay 1 (used for CRT2 only) */
@@ -3085,15 +3004,11 @@ MIRROR:
    if(pPriv->displayMode & DISPMODE_MIRROR &&
       index == 0			   &&
       pPriv->hasTwoOverlays) {
-#ifdef SISMERGED
       if((!pSiS->MergedFB) || overlay.DoSecond) {
-#endif
 	 index = 1; iscrt2 = 1;
 	 overlay.VBlankActiveFunc = vblank_active_CRT2;
 	 goto MIRROR;
-#ifdef SISMERGED
       }
-#endif
    }
 
    /* Now for the trigger: This is a bad hack to work-around
@@ -3136,11 +3051,9 @@ MIRROR:
 	 if(watchdog <= overlay.oldLine) {
 	    int i, mytop = overlay.oldtop;
 	    int screenHeight = overlay.SCREENheight;
-#ifdef SISMERGED
 	    if(pSiS->MergedFB) {
 	       screenHeight = overlay.SCREENheight2;
 	    }
-#endif
 	    if(mytop < screenHeight - 2) {
 	       do {
 	          watchdog = get_scanline_CRT2(pSiS, pPriv);
@@ -3886,11 +3799,6 @@ SISPutImageBlit(
    UChar  *ybased, *uvbased, packed;
    CARD16 *myuvbased;
    SiS_Packet12_YUV MyPacket;
-#if 0
-#ifdef SISMERGED
-   Bool first;
-#endif
-#endif
 
    if(index >= NUM_BLIT_PORTS) return BadMatch;
 
@@ -4027,40 +3935,6 @@ SISPutImageBlit(
 			   YUV_CMD_YUV			|
 			   DSTVIDEO;
 
-
-#if 0 /* Not implemented by hardware! */
-   if(pPriv->vsync) {
-#ifdef SISMERGED
-      if(!pSiS->MergedFB) {
-#endif
-#ifdef SISDUALHEAD
-         if(pSiS->DualHeadMode) {
-	    if(pSiS->SecondHead) {
-	       MyPacket.P12_Command |= pPriv->VBlankTriggerCRT1;
-	    } else {
-	       MyPacket.P12_Command |= pPriv->VBlankTriggerCRT2;
-	    }
-	 } else {
-#endif
-            Bool IsSlaveMode = SiSBridgeIsInSlaveMode(pScrn);
-            if((pSiS->VBFlags & DISPTYPE_DISP2) && !IsSlaveMode)
-	       MyPacket.P12_Command |= pPriv->VBlankTriggerCRT2;
-	    else if((pSiS->VBFlags & DISPTYPE_DISP1) || IsSlaveMode)
-	       MyPacket.P12_Command |= pPriv->VBlankTriggerCRT1;
-#ifdef SISDUALHEAD
-         }
-#endif
-#ifdef SISMERGED
-      }
-#endif
-   }
-#endif
-
-#if 0
-#ifdef SISMERGED
-   first = TRUE;
-#endif
-#endif
    while(nbox--) {
       left = pbox->x1;
       if(left >= drw_x + xoffset + width) goto mycont;
@@ -4083,23 +3957,6 @@ SISPutImageBlit(
       MyPacket.P12_DstY = top;
       MyPacket.P12_RectWidth = right - left;
       MyPacket.P12_RectHeight = bottom - top;
-
-#if 0
-#ifdef SISMERGED
-      if((first) && (pSiS->MergedFB)) {
-         int scrwidth = ((SiSMergedDisplayModePtr)pSiS->CurrentLayout.mode->Private)->CRT2->HDisplay;
-	 int scrheight = ((SiSMergedDisplayModePtr)pSiS->CurrentLayout.mode->Private)->CRT2->VDisplay;
-	 if( (right < pSiS->CRT2pScrn->frameX0) ||
-	     (left >= pSiS->CRT2pScrn->frameX0 + scrwidth) ||
-	     (bottom < pSiS->CRT2pScrn->frameY0) ||
-	     (top >= pSiS->CRT2pScrn->frameY0 + scrheight) ) {
-	    MyPacket.P12_Command |= pPriv->VBlankTriggerCRT1;
-	 } else {
-	    MyPacket.P12_Command |= pPriv->VBlankTriggerCRT2;
-	 }
-      }
-#endif
-#endif
 
       offsety = offsetuv = 0;
       if(packed) {
@@ -4148,11 +4005,6 @@ SISPutImageBlit(
       SISWriteBlitPacket(pSiS, (CARD32*)&MyPacket);
 #if 0
       MyPacket.P12_Command &= ~(pPriv->VBlankTriggerCRT1 | pPriv->VBlankTriggerCRT2);
-#endif
-#if 0
-#ifdef SISMERGED
-      first = FALSE;
-#endif
 #endif
 mycont:
       pbox++;

--- a/src/sis_video.h
+++ b/src/sis_video.h
@@ -406,7 +406,6 @@ typedef struct {
 
     DisplayModePtr  currentmode;
 
-#ifdef SISMERGED
     CARD16  pitch2;
     CARD16  HUSF2;
     CARD16  VUSF2;
@@ -427,7 +426,6 @@ typedef struct {
     DisplayModePtr  currentmode2;
 
     Bool    DoFirst, DoSecond;
-#endif
 
     CARD8   bobEnable;
 

--- a/src/sis_videostr.h
+++ b/src/sis_videostr.h
@@ -93,10 +93,8 @@ typedef struct {
     CARD8        linebufmask;
 
     short        oldx1, oldx2, oldy1, oldy2;
-#ifdef SISMERGED
     short        oldx1_2, oldx2_2, oldy1_2, oldy2_2;
     Bool    	 mustresettap2;
-#endif
     int          mustwait;
 
     Bool         grabbedByV4L;	   /* V4L stuff */


### PR DESCRIPTION
It's always enabled, so no need to have the code cluttered with those #ifdef's.