### PR TITLE
drop #ifdef SISDUALHEAD

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -3295,9 +3295,7 @@ SiSBIOSSetModeCRT2(struct SiS_Private *SiS_Pr, ScrnInfoPtr pScrn,
 {
    SISIOADDRESS BaseAddr = SiS_Pr->IOAddress;
    SISPtr  pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
    unsigned short ModeIdIndex;
    unsigned short ModeNo = 0;
    unsigned char  backupreg = 0;
@@ -3336,7 +3334,6 @@ SiSBIOSSetModeCRT2(struct SiS_Private *SiS_Pr, ScrnInfoPtr pScrn,
    SiSDetermineROMUsage(SiS_Pr);
 
    /* Save mode info so we can set it from within SetMode for CRT1 */
-#ifdef SISDUALHEAD
    if(pSiS->DualHeadMode) {
       pSiSEnt->CRT2ModeNo = ModeNo;
       pSiSEnt->CRT2DMode = mode;
@@ -3355,7 +3352,6 @@ SiSBIOSSetModeCRT2(struct SiS_Private *SiS_Pr, ScrnInfoPtr pScrn,
 #endif
       pSiSEnt->CRT2ModeSet = TRUE;
    }
-#endif
 
    if(SiS_Pr->UseCustomMode) {
 
@@ -3474,11 +3470,9 @@ SiSBIOSSetModeCRT1(struct SiS_Private *SiS_Pr, ScrnInfoPtr pScrn,
    SISPtr  pSiS = SISPTR(pScrn);
    unsigned short ModeIdIndex, ModeNo = 0;
    unsigned char  backupreg = 0;
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
    unsigned char  backupcr30, backupcr31, backupcr38, backupcr35, backupp40d=0;
    BOOLEAN backupcustom;
-#endif
 
    SiS_Pr->UseCustomMode = FALSE;
 
@@ -3563,12 +3557,10 @@ SiSBIOSSetModeCRT1(struct SiS_Private *SiS_Pr, ScrnInfoPtr pScrn,
 
    SiS_CloseCRTC(SiS_Pr);
 
-#ifdef SISDUALHEAD
    if(pSiS->DualHeadMode) {
       pSiSEnt->CRT1ModeNo = ModeNo;
       pSiSEnt->CRT1DMode = mode;
    }
-#endif
 
    if(SiS_Pr->UseCustomMode) {
       SiS_Pr->CRT1UsesCustomMode = TRUE;
@@ -3579,7 +3571,6 @@ SiSBIOSSetModeCRT1(struct SiS_Private *SiS_Pr, ScrnInfoPtr pScrn,
    }
 
    /* Reset CRT2 if changing mode on CRT1 */
-#ifdef SISDUALHEAD
    if(pSiS->DualHeadMode) {
       if(pSiSEnt->CRT2ModeNo != -1) {
 	 xf86DrvMsgVerb(pScrn->scrnIndex, X_INFO, 3,
@@ -3615,7 +3606,6 @@ SiSBIOSSetModeCRT1(struct SiS_Private *SiS_Pr, ScrnInfoPtr pScrn,
 	 SiS_Pr->UseCustomMode = backupcustom;
       }
    }
-#endif
 
    /* Warning: From here, the custom mode entries in SiS_Pr are
     * possibly overwritten

--- a/src/sis.h
+++ b/src/sis.h
@@ -137,8 +137,6 @@
 
 /* Configurable stuff: ------------------------------------- */
 
-#define SISDUALHEAD		/* Include Dual Head code  */
-
 #define SISXINERAMA		/* Include SiS Pseudo-Xinerama for MergedFB mode */
 #define SIS_XINERAMA_MAJOR_VERSION  1
 #define SIS_XINERAMA_MINOR_VERSION  1
@@ -679,7 +677,6 @@ typedef struct {
 typedef void (*vidCopyFunc)(UChar *, const UChar *, int);
 
 /* Dual head private entity structure */
-#ifdef SISDUALHEAD
 typedef struct {
     ScrnInfoPtr		pScrn_1;
     ScrnInfoPtr		pScrn_2;
@@ -805,7 +802,6 @@ typedef struct {
     vidCopyFunc		SiSFastVidCopyFrom, SiSFastMemCopyFrom;
     unsigned int	CPUFlags;
 } SISEntRec, *SISEntPtr;
-#endif
 
 #define SISPTR(p)       ((SISPtr)((p)->driverPrivate))
 #define XAAPTR(p)       ((XAAInfoRecPtr)(SISPTR(p)->AccelInfoPtr))
@@ -1034,12 +1030,10 @@ typedef struct {
     CARD8		*fonts;
     void		*state, *pstate;
     void		*base, *VGAbase;
-#ifdef SISDUALHEAD
     Bool		DualHeadMode;		/* TRUE if we use dual head mode */
     Bool		SecondHead;		/* TRUE is this is the second head */
     SISEntPtr		entityPrivate;		/* Ptr to private entity (see above) */
     Bool		SiSXinerama;		/* Do we use Xinerama mode? */
-#endif
     SISFBLayout		CurrentLayout;		/* Current framebuffer layout */
     UShort		SiS_DDC2_Index;
     UShort		SiS_DDC2_Data;

--- a/src/sis300_accel.c
+++ b/src/sis300_accel.c
@@ -115,12 +115,10 @@ SiSSubsequentScreenToScreenCopy(ScrnInfoPtr pScrn,
 	   dstbase = pSiS->scrnOffset * dst_y;
 	   dst_y = 0;
 	}
-#ifdef SISDUALHEAD
 	if(pSiS->VGAEngine != SIS_530_VGA) {
 	   srcbase += HEADOFFSET;
 	   dstbase += HEADOFFSET;
 	}
-#endif
 	SiSSetupSRCBase(srcbase);
 	SiSSetupDSTBase(dstbase);
 
@@ -168,11 +166,9 @@ SiSSubsequentSolidFillRect(ScrnInfoPtr pScrn,
 	   dstbase = pSiS->scrnOffset * y;
 	   y = 0;
 	}
-#ifdef SISDUALHEAD
         if(pSiS->VGAEngine != SIS_530_VGA) {
 	   dstbase += HEADOFFSET;
         }
-#endif
 	SiSSetupDSTBase(dstbase)
 	SiSSetupDSTXY(x,y)
 	SiSSetupRect(w,h)

--- a/src/sis310_accel.c
+++ b/src/sis310_accel.c
@@ -97,20 +97,14 @@ static void
 SiSCalcRenderAccelArray(ScrnInfoPtr pScrn)
 {
 	SISPtr  pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
 	SISEntPtr pSiSEnt = pSiS->entityPrivate;;
-#endif
 
 	if(((pScrn->bitsPerPixel == 16) || (pScrn->bitsPerPixel == 32)) && pSiS->doRender) {
 	   int i, j;
-#ifdef SISDUALHEAD
 	   if(pSiSEnt) pSiS->RenderAccelArray = pSiSEnt->RenderAccelArray;
-#endif
 	   if(!pSiS->RenderAccelArray) {
 	      if((pSiS->RenderAccelArray = XNFcallocarray(65536, 1))) {
-#ifdef SISDUALHEAD
 	         if(pSiSEnt) pSiSEnt->RenderAccelArray = pSiS->RenderAccelArray;
-#endif
 		 for(i = 0; i < 256; i++) {
 		    for(j = 0; j < 256; j++) {
 		       pSiS->RenderAccelArray[(i << 8) + j] = (i * j) / 255;

--- a/src/sis_cursor.c
+++ b/src/sis_cursor.c
@@ -81,7 +81,6 @@ SiSXConvertMono2ARGB(SISPtr pSiS)
    }
 }
 
-#ifdef SISDUALHEAD
 static void
 UpdateHWCursorStatus(SISPtr pSiS)
 {
@@ -93,7 +92,6 @@ UpdateHWCursorStatus(SISPtr pSiS)
        pSiS->HWCursorBackup[offs + i] = SIS_MMIO_IN32(pSiS->IOBase, 0x8500 + ((offs + i) << 2));
     }
 }
-#endif
 
 static void
 SiSHideCursor(ScrnInfoPtr pScrn)
@@ -115,7 +113,6 @@ SiS300HideCursor(ScrnInfoPtr pScrn)
 {
     SISPtr  pSiS = SISPTR(pScrn);
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode && (!pSiS->ForceCursorOff)) {
        if(pSiS->SecondHead) {
 	  /* Head 2 is always CRT1 */
@@ -127,16 +124,13 @@ SiS300HideCursor(ScrnInfoPtr pScrn)
 	  sis301SetCursorPositionY(2000, 0)
        }
     } else {
-#endif
        sis300DisableHWCursor()
        sis300SetCursorPositionY(2000, 0)
        if(pSiS->VBFlags & CRT2_ENABLE)  {
           sis301DisableHWCursor()
 	  sis301SetCursorPositionY(2000, 0)
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static void
@@ -146,7 +140,6 @@ SiS310HideCursor(ScrnInfoPtr pScrn)
 
     pSiS->HWCursorIsVisible = FALSE;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode && (!pSiS->ForceCursorOff)) {
        if(pSiS->SecondHead) {
 	  /* Head 2 is always CRT1 */
@@ -158,16 +151,13 @@ SiS310HideCursor(ScrnInfoPtr pScrn)
 	  sis301SetCursorPositionY310(2000, 0)
        }
     } else {
-#endif
        sis310DisableHWCursor()
        sis310SetCursorPositionY(2000, 0)
        if(pSiS->VBFlags2 & VB2_VIDEOBRIDGE) {
 	  sis301DisableHWCursor310()
 	  sis301SetCursorPositionY310(2000, 0)
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static void
@@ -193,7 +183,6 @@ SiS300ShowCursor(ScrnInfoPtr pScrn)
 {
     SISPtr  pSiS = SISPTR(pScrn);
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiS->SecondHead) {
 	  /* Head 2 is always CRT1 */
@@ -211,7 +200,6 @@ SiS300ShowCursor(ScrnInfoPtr pScrn)
 	  }
        }
     } else {
-#endif
        if(pSiS->UseHWARGBCursor) {
 	  sis300EnableHWARGBCursor()
 	  if(pSiS->VBFlags & CRT2_ENABLE)  {
@@ -223,9 +211,7 @@ SiS300ShowCursor(ScrnInfoPtr pScrn)
              sis301EnableHWCursor()
 	  }
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static void
@@ -241,7 +227,6 @@ SiS310ShowCursor(ScrnInfoPtr pScrn)
 
     pSiS->HWCursorIsVisible = TRUE;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiS->SecondHead) {
 	  /* Head 2 is always CRT1 */
@@ -263,7 +248,6 @@ SiS310ShowCursor(ScrnInfoPtr pScrn)
 	  }
        }
     } else {
-#endif
        if(pSiS->ChipFlags & SiSCF_CRT2HWCKaputt) {
 	  if(pSiS->UseHWARGBCursor) {
 	     sis310EnableHWARGBCursor()
@@ -286,9 +270,7 @@ SiS310ShowCursor(ScrnInfoPtr pScrn)
 	     }
 	  }
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static void
@@ -428,7 +410,6 @@ SiS300SetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
        y = 0;
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiS->SecondHead) {
 	  /* Head 2 is always CRT1 */
@@ -440,16 +421,13 @@ SiS300SetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
 	  sis301SetCursorPositionY(y, y_preset)
        }
     } else {
-#endif
        sis300SetCursorPositionX(x, x_preset)
        sis300SetCursorPositionY(y, y_preset)
        if(pSiS->VBFlags & CRT2_ENABLE) {
 	  sis301SetCursorPositionX(x + 13, x_preset)
 	  sis301SetCursorPositionY(y, y_preset)
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static void
@@ -477,7 +455,6 @@ SiS310SetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
        y = 0;
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiS->SecondHead) {
 	  /* Head 2 is always CRT1 */
@@ -495,7 +472,6 @@ SiS310SetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
 	  sis301SetCursorPositionY310(y, y_preset)
        }
     } else {
-#endif
        sis310SetCursorPositionX(x, x_preset)
        sis310SetCursorPositionY(y, y_preset)
        if(pSiS->VBFlags & CRT2_ENABLE) {
@@ -508,9 +484,7 @@ SiS310SetCursorPosition(ScrnInfoPtr pScrn, int x, int y)
 	  sis301SetCursorPositionX310(x + 17, x_preset)
 	  sis301SetCursorPositionY310(y, y_preset)
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static void
@@ -549,7 +523,6 @@ SiS300SetCursorColors(ScrnInfoPtr pScrn, int bg, int fg)
 
     if(pSiS->UseHWARGBCursor) return;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiS->SecondHead) {
 	  /* Head 2 is always CRT1 */
@@ -561,16 +534,13 @@ SiS300SetCursorColors(ScrnInfoPtr pScrn, int bg, int fg)
           sis301SetCursorFGColor(fg)
        }
     } else {
-#endif
        sis300SetCursorBGColor(bg)
        sis300SetCursorFGColor(fg)
        if(pSiS->VBFlags & CRT2_ENABLE)  {
           sis301SetCursorBGColor(bg)
           sis301SetCursorFGColor(fg)
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static void
@@ -580,7 +550,6 @@ SiS310SetCursorColors(ScrnInfoPtr pScrn, int bg, int fg)
 
     if(pSiS->UseHWARGBCursor) return;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
 	if(pSiS->SecondHead) {
 	   /* Head 2 is always CRT1 */
@@ -600,7 +569,6 @@ SiS310SetCursorColors(ScrnInfoPtr pScrn, int bg, int fg)
 	   }
        }
     } else {
-#endif
        sis310SetCursorBGColor(bg)
        sis310SetCursorFGColor(fg)
 
@@ -616,9 +584,7 @@ SiS310SetCursorColors(ScrnInfoPtr pScrn, int bg, int fg)
 	     sis301SetCursorFGColor310(fg)
 	  }
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static void
@@ -678,9 +644,7 @@ SiS300LoadCursorImage(ScrnInfoPtr pScrn, UChar *src)
     CARD32 status1 = 0, status2 = 0;
     UChar  *dest = pSiS->RealFbBase;
     Bool   sizedouble = FALSE;
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
     if(pSiS->MergedFB) {
        if((CDMPTR->CRT1->Flags & V_DBLSCAN) && (CDMPTR->CRT2->Flags & V_DBLSCAN)) {
@@ -692,10 +656,8 @@ SiS300LoadCursorImage(ScrnInfoPtr pScrn, UChar *src)
 
     cursor_addr = pScrn->videoRam - pSiS->cursorOffset - (pSiS->CursorSize/1024);  /* 1K boundary */
 
-#ifdef SISDUALHEAD
     /* Use the global FbBase in DHM */
     if(pSiS->DualHeadMode) dest = pSiSEnt->RealFbBase;
-#endif
 
     if(sizedouble) {
        int i;
@@ -709,11 +671,9 @@ SiS300LoadCursorImage(ScrnInfoPtr pScrn, UChar *src)
        SiSMemCopyToVideoRam(pSiS, (UChar *)dest + (cursor_addr * 1024), src, 1024);
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        UpdateHWCursorStatus(pSiS);
     }
-#endif
 
     if(pSiS->UseHWARGBCursor) {
        if(pSiS->VBFlags & DISPTYPE_CRT1) {
@@ -761,19 +721,15 @@ SiS310LoadCursorImage(ScrnInfoPtr pScrn, UChar *src)
     UChar *dest = pSiS->RealFbBase;
     Bool  sizedouble = FALSE;
     int bufnum;
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
     if(pSiS->DualHeadMode) {
        pSiSEnt->HWCursorMBufNum ^= 1;
        bufnum = 1 << pSiSEnt->HWCursorMBufNum;
     } else {
-#endif
        pSiS->HWCursorMBufNum ^= 1;
        bufnum = 1 << pSiS->HWCursorMBufNum;
-#ifdef SISDUALHEAD
     }
-#endif
 
     if(pSiS->MergedFB) {
        if((CDMPTR->CRT1->Flags & V_DBLSCAN) && (CDMPTR->CRT2->Flags & V_DBLSCAN)) {
@@ -783,10 +739,8 @@ SiS310LoadCursorImage(ScrnInfoPtr pScrn, UChar *src)
        sizedouble = TRUE;
     }
 
-#ifdef SISDUALHEAD
     /* Use the global FbBase in DHM */
     if(pSiS->DualHeadMode) dest = pSiSEnt->RealFbBase;
-#endif
 
     if(pSiS->ChipFlags & SiSCF_CRT2HWCKaputt) {
        cursor_addr = pScrn->videoRam - pSiS->cursorOffset - (pSiS->CursorSize/1024);
@@ -806,11 +760,9 @@ SiS310LoadCursorImage(ScrnInfoPtr pScrn, UChar *src)
        SiSMemCopyToVideoRam(pSiS, (UChar *)dest + (cursor_addr * 1024), src, 1024);
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        UpdateHWCursorStatus(pSiS);
     }
-#endif
 
     if(pSiS->ChipFlags & SiSCF_CRT2HWCKaputt) {
 
@@ -926,9 +878,7 @@ SiS300UseHWCursor(ScreenPtr pScreen, CursorPtr pCurs)
 	 break;
 
       case PCI_CHIP_SIS550:
-#ifdef SISDUALHEAD
 	 if((!pSiS->DualHeadMode) || (!pSiS->SecondHead))
-#endif
 	    if((pSiS->FSTN || pSiS->DSTN) && (pSiS->VBFlags & CRT2_LCD))
 	       return FALSE;
 	 /* fall through */
@@ -995,9 +945,7 @@ SiSUseHWCursorARGB(ScreenPtr pScreen, CursorPtr pCurs)
          break;
 
       case PCI_CHIP_SIS550:
-#ifdef SISDUALHEAD
 	 if((!pSiS->DualHeadMode) || (!pSiS->SecondHead))
-#endif
 	    if((pSiS->FSTN || pSiS->DSTN) && (pSiS->VBFlags & CRT2_LCD))
 	       return FALSE;
 	 /* fall through */
@@ -1045,9 +993,7 @@ SiS300LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
     int srcheight = pCurs->bits->height;
     CARD32 temp, status1 = 0, status2 = 0;
     Bool sizedouble = FALSE;
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
     if(pSiS->MergedFB) {
        if((CDMPTR->CRT1->Flags & V_DBLSCAN) && (CDMPTR->CRT2->Flags & V_DBLSCAN)) {
@@ -1062,11 +1008,9 @@ SiS300LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
     if(srcwidth > 32)  srcwidth = 32;
     if(srcheight > 32) srcheight = 32;
 
-#ifdef SISDUALHEAD
     if (pSiS->DualHeadMode)
 	dest = (MYSISPTRTYPE *)((UChar *)pSiSEnt->RealFbBase + (cursor_addr * 1024));
     else
-#endif
         dest = (MYSISPTRTYPE *)((UChar *)pSiS->RealFbBase + (cursor_addr * 1024));
 
     if(sizedouble) {
@@ -1119,11 +1063,9 @@ SiS300LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
 	}
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        UpdateHWCursorStatus(pSiS);
     }
-#endif
 
     if(!pSiS->UseHWARGBCursor) {
        if(pSiS->VBFlags & DISPTYPE_CRT1) {
@@ -1173,9 +1115,7 @@ static void SiS310LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
     CARD32 status1 = 0, status2 = 0;
     Bool sizedouble = FALSE;
     int bufnum;
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
     if(pSiS->MergedFB) {
        if((CDMPTR->CRT1->Flags & V_DBLSCAN) && (CDMPTR->CRT2->Flags & V_DBLSCAN)) {
@@ -1185,17 +1125,13 @@ static void SiS310LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
        sizedouble = TRUE;
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        pSiSEnt->HWCursorCBufNum ^= 1;
        bufnum = 1 << pSiSEnt->HWCursorCBufNum;
     } else {
-#endif
        pSiS->HWCursorCBufNum ^= 1;
        bufnum = 1 << pSiS->HWCursorCBufNum;
-#ifdef SISDUALHEAD
     }
-#endif
 
     if(pSiS->ChipFlags & SiSCF_CRT2HWCKaputt) {
        cursor_addr = pScrn->videoRam - pSiS->cursorOffset - ((pSiS->CursorSize/1024) * 2);
@@ -1206,11 +1142,9 @@ static void SiS310LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
     if(srcwidth > 64)  srcwidth = 64;
     if(srcheight > 64) srcheight = 64;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode)
        dest = (CARD32 *)((UChar *)pSiSEnt->RealFbBase + (cursor_addr * 1024));
     else
-#endif
        dest = (CARD32 *)((UChar *)pSiS->RealFbBase + (cursor_addr * 1024));
 
     if(sizedouble) {
@@ -1241,11 +1175,9 @@ static void SiS310LoadCursorImageARGB(ScrnInfoPtr pScrn, CursorPtr pCurs)
        }
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        UpdateHWCursorStatus(pSiS);
     }
-#endif
 
     if(pSiS->ChipFlags & SiSCF_CRT2HWCKaputt) {
        if(!pSiS->UseHWARGBCursor) {

--- a/src/sis_dac.c
+++ b/src/sis_dac.c
@@ -1412,9 +1412,7 @@ SiSEstimateCRT2Clock(ScrnInfoPtr pScrn, Bool FakeForCRT2)
 int SiSMemBandWidth(ScrnInfoPtr pScrn, Bool IsForCRT2)
 {
 	SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
 	SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 	int          bus = pSiS->BusWidth;
 	int          mclk = pSiS->MemClock;
 	int          bpp = pSiS->CurrentLayout.bitsPerPixel;
@@ -1542,12 +1540,10 @@ int SiSMemBandWidth(ScrnInfoPtr pScrn, Bool IsForCRT2)
 		    DHM = FALSE;
 		    GetForCRT1 = FALSE;
 
-#ifdef SISDUALHEAD
 		    if((pSiS->DualHeadMode) && (pSiSEnt)) {
 		       DHM = TRUE;
 		       if(pSiS->SecondHead) GetForCRT1 = TRUE;
 		    }
-#endif
 		    if(pSiS->MergedFB && IsForCRT2) {
 		       DHM = TRUE;
 		       GetForCRT1 = FALSE;
@@ -1593,7 +1589,6 @@ int SiSMemBandWidth(ScrnInfoPtr pScrn, Bool IsForCRT2)
 				      crt2used/1000);
 
 			} else {
-#ifdef SISDUALHEAD
 			     /* Second head = CRT1 */
 
 			     /*     Now We know about the first head's depth,
@@ -1616,7 +1611,6 @@ int SiSMemBandWidth(ScrnInfoPtr pScrn, Bool IsForCRT2)
 
 			     xf86DrvMsg(pScrn->scrnIndex, X_PROBED,
 				 "Bandwidth available for CRT1 is %g MHz\n", total/1000);
-#endif
 			}
 
 		    } else {
@@ -1670,17 +1664,13 @@ SISLoadPalette(ScrnInfoPtr pScrn, int numColors, int *indices, LOCO *colors,
      UChar   backup = 0;
      Bool    dogamma1 = pSiS->CRT1gamma;
      Bool    resetxvgamma = FALSE;
-#ifdef SISDUALHEAD
      SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
      if(pSiS->DualHeadMode) dogamma1 = pSiSEnt->CRT1gamma;
-#endif
 
      PDEBUG(xf86DrvMsg(pScrn->scrnIndex, X_INFO, "LoadPalette()\n"));
 
-#ifdef SISDUALHEAD
      if((!pSiS->DualHeadMode) || (pSiS->SecondHead)) {
-#endif
 
 	if(pSiS->VGAEngine == SIS_315_VGA) {
 	   inSISIDXREG(SISSR, 0x1f, backup);
@@ -1807,13 +1797,9 @@ SISLoadPalette(ScrnInfoPtr pScrn, int numColors, int *indices, LOCO *colors,
 	   }
 	}
 
-#ifdef SISDUALHEAD
     }
-#endif
 
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead)) {
-#endif
        switch(pSiS->VGAEngine) {
        case SIS_300_VGA:
        case SIS_315_VGA:
@@ -1828,10 +1814,7 @@ SISLoadPalette(ScrnInfoPtr pScrn, int numColors, int *indices, LOCO *colors,
 	     }
           }
        }
-#ifdef SISDUALHEAD
     }
-#endif
-
 }
 
 void
@@ -1841,9 +1824,7 @@ SiS_UpdateGammaCRT2(ScrnInfoPtr pScrn)
 
     if((!pSiS->CRT2SepGamma) || (!pSiS->crt2cindices) || (!pSiS->crt2gcolortable)) return;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) return;
-#endif
 
     SISCalculateGammaRampCRT2(pScrn);
     SiS301LoadPalette(pScrn, pSiS->CRT2ColNum, pSiS->crt2cindices, pSiS->crt2colors, (8 - pScrn->rgbBits));
@@ -1855,11 +1836,9 @@ SiS301LoadPalette(ScrnInfoPtr pScrn, int numColors, int *indices, LOCO *colors, 
 	SISPtr  pSiS = SISPTR(pScrn);
 	int     i, j, index;
 	Bool    dogamma2 = pSiS->CRT2gamma;
-#ifdef SISDUALHEAD
 	SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
 	if(pSiS->DualHeadMode) dogamma2 = pSiSEnt->CRT2gamma;
-#endif
 
 	/* 301B-DH does not support a color palette for LCD */
 	if((pSiS->VBFlags2 & VB2_30xBDH) && (pSiS->VBFlags & CRT2_LCD)) return;
@@ -1935,10 +1914,8 @@ SISDACPreInit(ScrnInfoPtr pScrn)
     SISPtr pSiS = SISPTR(pScrn);
     Bool IsForCRT2 = FALSE;
 
-#ifdef SISDUALHEAD
     if((pSiS->DualHeadMode) && (!pSiS->SecondHead))
        IsForCRT2 = TRUE;
-#endif
 
     pSiS->MaxClock = SiSMemBandWidth(pScrn, IsForCRT2);
 

--- a/src/sis_dga.c
+++ b/src/sis_dga.c
@@ -249,9 +249,7 @@ SISDGAInit(ScreenPtr pScreen)
    /* We don't support 8bpp modes in dual head or MergedFB mode,
     * so don't offer them to DGA either.
     */
-#ifdef SISDUALHEAD
    if(!pSiS->DualHeadMode) {
-#endif
       if(!(pSiS->MergedFB)) {
          modes = SISSetupDGAMode(pScrn, modes, &num, 8, 8,
 				 (pScrn->bitsPerPixel == 8),
@@ -259,9 +257,7 @@ SISDGAInit(ScreenPtr pScreen)
 				     ? 0 : pScrn->displayWidth),
 				 0, 0, 0, PseudoColor);
       }
-#ifdef SISDUALHEAD
    }
-#endif
 
    /* 16 */
    modes = SISSetupDGAMode(pScrn, modes, &num, 16, 16,

--- a/src/sis_driver.c
+++ b/src/sis_driver.c
@@ -92,9 +92,7 @@
 int 		sisdevport = 0;
 #endif
 
-#ifdef SISDUALHEAD
 static int	SISEntityIndex = -1;
-#endif
 
 #ifdef SISXINERAMA
 static Bool 		SiSnoPanoramiXExtension = TRUE;
@@ -245,23 +243,18 @@ static void
 SISFreeRec(ScrnInfoPtr pScrn)
 {
     SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = NULL;
-#endif
 
     /* Just to make sure... */
     if(!pSiS) return;
 
-#ifdef SISDUALHEAD
     pSiSEnt = pSiS->entityPrivate;
-#endif
 
     free(pSiS->pstate);
     pSiS->pstate = NULL;
     free(pSiS->fonts);
     pSiS->fonts = NULL;
 
-#ifdef SISDUALHEAD
     if(pSiSEnt) {
        if(!pSiS->SecondHead) {
 	  /* Free memory only if we are first head; in case of an error
@@ -283,16 +276,13 @@ SISFreeRec(ScrnInfoPtr pScrn)
 	  pSiSEnt->pScrn_2 = NULL;
        }
     } else {
-#endif
        free(pSiS->BIOS);
        pSiS->BIOS = NULL;
        free(pSiS->SiS_Pr);
        pSiS->SiS_Pr = NULL;
        free(pSiS->RenderAccelArray);
        pSiS->RenderAccelArray = NULL;
-#ifdef SISDUALHEAD
     }
-#endif
     free(pSiS->CRT2HSync);
     pSiS->CRT2HSync = NULL;
     free(pSiS->CRT2VRefresh);
@@ -459,9 +449,7 @@ SISProbe(DriverPtr drv, int flags)
     } else for(i = 0; i < numUsed; i++) {
 
 	ScrnInfoPtr pScrn;
-#ifdef SISDUALHEAD
 	EntityInfoPtr pEnt;
-#endif
 
 	/* Allocate a ScrnInfoRec and claim the slot */
 	pScrn = NULL;
@@ -487,7 +475,6 @@ SISProbe(DriverPtr drv, int flags)
 	    foundScreen = TRUE;
 	}
 
-#ifdef SISDUALHEAD
 	pEnt = xf86GetEntityInfo((i < numUsedSiS) ? usedChipsSiS[i] : usedChipsXGI[i-numUsedSiS]);
 
 	if(pEnt->chipset == PCI_CHIP_SIS630 || pEnt->chipset == PCI_CHIP_SIS540 ||
@@ -517,8 +504,6 @@ SISProbe(DriverPtr drv, int flags)
 	    xf86SetEntityInstanceForScreen(pScrn, pScrn->entityList[0],
 	                                   pSiSEnt->lastInstance);
 	}
-#endif /* DUALHEAD */
-
     }
 
     free(usedChipsSiS);
@@ -865,7 +850,6 @@ SiSAllowSyncOverride(SISPtr pSiS, Bool fromDDC)
 {
    if(!(pSiS->VBFlags2 & VB2_VIDEOBRIDGE)) return FALSE;
 
-#ifdef SISDUALHEAD
    if(pSiS->DualHeadMode) {
       if(pSiS->SecondHead) {
          if((pSiS->VBFlags & CRT1_LCDA) && (!fromDDC)) return TRUE;
@@ -875,7 +859,6 @@ SiSAllowSyncOverride(SISPtr pSiS, Bool fromDDC)
       }
       return FALSE;
    }
-#endif
 
    if(pSiS->MergedFB) {
       if((pSiS->VBFlags & CRT1_LCDA) && (!fromDDC)) return TRUE;
@@ -2516,7 +2499,6 @@ SiSDoPrivateDDC(ScrnInfoPtr pScrn, int *crtnum)
 {
     SISPtr pSiS = SISPTR(pScrn);
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiS->SecondHead) {
           *crtnum = 1;
@@ -2526,7 +2508,6 @@ SiSDoPrivateDDC(ScrnInfoPtr pScrn, int *crtnum)
 	  return(SiSInternalDDC(pScrn, 1));
        }
     } else
-#endif
     if((pSiS->CRT1off) || (!pSiS->CRT1Detected)) {
        *crtnum = 2;
        return(SiSInternalDDC(pScrn, 1));
@@ -3010,9 +2991,7 @@ static Bool
 SISPreInit(ScrnInfoPtr pScrn, int flags)
 {
     SISPtr pSiS;
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = NULL;
-#endif
     MessageType from;
     UChar usScratchCR17, usScratchCR32, usScratchCR63;
     UChar usScratchSR1F, srlockReg, crlockReg;
@@ -3117,7 +3096,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        goto my_error_0;
     }
 
-#ifdef SISDUALHEAD
     /* Allocate an entity private if necessary */
     if(xf86IsEntityShared(pScrn->entityList[0])) {
        pSiSEnt = xf86GetEntityPrivate(pScrn->entityList[0], SISEntityIndex)->ptr;
@@ -3129,7 +3107,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	  goto my_error_0;
        }
     }
-#endif
 
     /* Find the PCI info for this screen */
     pSiS->PciInfo = xf86GetPciInfoForEntity(pSiS->pEnt->index);
@@ -3619,7 +3596,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	  break;
     }
 
-#ifdef SISDUALHEAD
     /* In case of Dual Head, we need to determine if we are the "master" head or
      * the "slave" head. In order to do that, we set PrimInit to DONE in the
      * shared entity at the end of the first initialization. The second
@@ -3660,7 +3636,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        pSiS->SecondHead = FALSE;
        pSiS->DualHeadMode = FALSE;
     }
-#endif
 
     /* Save the name of our Device section for SiSCtrl usage */
     {
@@ -3678,19 +3653,15 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 
     /* Allocate SiS_Private (for mode switching code) and initialize it */
     pSiS->SiS_Pr = NULL;
-#ifdef SISDUALHEAD
     if(pSiSEnt) {
        if(pSiSEnt->SiS_Pr) pSiS->SiS_Pr = pSiSEnt->SiS_Pr;
     }
-#endif
     if(!pSiS->SiS_Pr) {
        if(!(pSiS->SiS_Pr = XNFcallocarray(1, sizeof(struct SiS_Private)))) {
 	  SISErrorLog(pScrn, "Could not allocate memory for SiS_Pr structure\n");
 	  goto my_error_1;
        }
-#ifdef SISDUALHEAD
        if(pSiSEnt) pSiSEnt->SiS_Pr = pSiS->SiS_Pr;
-#endif
        memset(pSiS->SiS_Pr, 0, sizeof(struct SiS_Private));
        pSiS->SiS_Pr->ChipType = pSiS->ChipType;
        pSiS->SiS_Pr->ChipRevision = pSiS->ChipRev;
@@ -3866,14 +3837,12 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        }
     }
 
-#ifdef SISDUALHEAD
     /* Due to palette & timing problems we don't support 8bpp in DHM */
     if((pSiS->DualHeadMode) && (pScrn->bitsPerPixel <= 8)) {
        SISErrorLog(pScrn, "Color depth %d not supported in Dual Head mode.\n",
 			pScrn->bitsPerPixel);
        goto my_error_1;
     }
-#endif
 
     /* Read BIOS for 300/315/330/340 series customization */
     pSiS->SiS_Pr->VirtualRomBase = NULL;
@@ -3883,7 +3852,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
     pSiS->HaveXGIBIOS = FALSE;
 
     if((pSiS->VGAEngine == SIS_300_VGA) || (pSiS->VGAEngine == SIS_315_VGA)) {
-#ifdef SISDUALHEAD
        if(pSiSEnt) {
 	  if(pSiSEnt->BIOS) {
 	     pSiS->BIOS = pSiSEnt->BIOS;
@@ -3892,7 +3860,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     pSiS->HaveXGIBIOS = pSiSEnt->HaveXGIBIOS;
 	  }
        }
-#endif
        if(!pSiS->BIOS) {
 	  if(!(pSiS->BIOS = calloc(1, BIOS_SIZE))) {
 	     xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
@@ -3953,13 +3920,11 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 		   xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
 			"*** same time, BIOS and driver will be unable to detect DVI connection.\n");
 		}
-#ifdef SISDUALHEAD
 		if(pSiSEnt) {
 		   pSiSEnt->BIOS = pSiS->BIOS;
 		   pSiSEnt->ROM661New = pSiS->ROM661New;
 		   pSiSEnt->HaveXGIBIOS = pSiS->HaveXGIBIOS;
 		}
-#endif
 	     } else {
 	        xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
 			 "Could not find/read video BIOS\n");
@@ -3986,17 +3951,13 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
     }
 
     /* Probe CPU features */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        pSiS->CPUFlags = pSiSEnt->CPUFlags;
     }
-#endif
     if(!pSiS->CPUFlags) {
        pSiS->CPUFlags = SiSGetCPUFlags(pScrn);
        pSiS->CPUFlags |= SIS_CPUFL_FLAG;
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode) pSiSEnt->CPUFlags = pSiS->CPUFlags;
-#endif
     }
 
     /* We use a programamble clock */
@@ -4005,7 +3966,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
     /* Set the bits per RGB for 8bpp mode */
     if(pScrn->depth == 8) pScrn->rgbBits = 8;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(!pSiS->SecondHead) {
 	  /* Copy some option settings to entity private */
@@ -4151,7 +4111,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	  pSiSEnt->NewGammaConB = pSiS->NewGammaConB;
        }
     }
-#endif
 
     /* Handle UseROMData, NoOEM and UsePanelScaler options */
     if((pSiS->VGAEngine == SIS_300_VGA) || (pSiS->VGAEngine == SIS_315_VGA)) {
@@ -4186,12 +4145,10 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        from = X_PROBED;
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode)
        xf86DrvMsg(pScrn->scrnIndex, from, "Global linear framebuffer at 0x%lX\n",
 	   (ULong)pSiS->FbAddress);
     else
-#endif
        xf86DrvMsg(pScrn->scrnIndex, from, "Linear framebuffer at 0x%lX\n",
 	   (ULong)pSiS->FbAddress);
 
@@ -4275,9 +4232,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	pSiS->CmdQueLenMask = 0xFFFF;
 	pSiS->CmdQueLenFix  = 0;
 	pSiS->cursorBufferNum = 0;
-#ifdef SISDUALHEAD
 	if(pSiSEnt) pSiSEnt->cursorBufferNum = 0;
-#endif
 	break;
 
       case SIS_315_VGA:
@@ -4291,11 +4246,9 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	pSiS->cursorOffset = (pSiS->cmdQueueSize / 1024);
 
 	/* Set up shared pointer to current offset */
-#ifdef SISDUALHEAD
 	if(pSiS->DualHeadMode)
 	   pSiS->cmdQ_SharedWritePort = &(pSiSEnt->cmdQ_SharedWritePort_2D);
 	else
-#endif
 	   pSiS->cmdQ_SharedWritePort = &(pSiS->cmdQ_SharedWritePort_2D);
 
 	if(pSiS->HWCursor) {
@@ -4303,9 +4256,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	   if(pSiS->OptUseColorCursor) pSiS->availMem -= (pSiS->CursorSize * 2);
 	}
 	pSiS->cursorBufferNum = 0;
-#ifdef SISDUALHEAD
 	if(pSiSEnt) pSiSEnt->cursorBufferNum = 0;
-#endif
 
 	if((pSiS->SiS76xLFBSize) && (pSiS->SiS76xUMASize)) {
 	   pSiS->availMem -= pSiS->SiS76xUMASize;
@@ -4367,16 +4318,13 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
     }
 
 
-#ifdef SISDUALHEAD
     /* In dual head mode, we share availMem equally - so align it
      * to 8KB; this way, the address of the FB of the second
      * head is aligned to 4KB for mapping.
      */
    if(pSiS->DualHeadMode) pSiS->availMem &= 0xFFFFE000;
-#endif
 
     /* Check MaxXFBMem setting */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
         /* 1. Since DRI is not supported in dual head mode, we
 	 *    don't need the MaxXFBMem setting - ignore it.
@@ -4387,7 +4335,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	}
 	pSiS->maxxfbmem = pSiS->availMem;
     } else
-#endif
 	   if((pSiS->sisfbHeapStart) || (pSiS->sisfbHaveNewHeapDef)) {
 
        /*
@@ -4863,11 +4810,9 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        }
     }
 
-#ifdef SISDUALHEAD
     if(!pSiS->DualHeadMode) {
        pSiS->SiS_SD_Flags |= SiS_SD_SUPPORTREDETECT;
     }
-#endif
 
 #ifndef SISCHECKOSSSE
     pSiS->SiS_SD2_Flags |= SiS_SD2_NEEDUSESSE;
@@ -4948,9 +4893,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	  } else if(pSiS->LCDwidth > 1600) {
 	     /* If LCD is > 1600, default to LCDA if we don't need CRT1/VGA for other head */
 	     Bool NeedCRT1VGA = FALSE;
-#ifdef SISDUALHEAD
 	     if(pSiS->DualHeadMode) NeedCRT1VGA = TRUE;
-#endif
 	     if(pSiS->MergedFB &&
 		(!pSiS->MergedFBAuto || pSiS->CRT1Detected)) NeedCRT1VGA = TRUE;
 	     if(!NeedCRT1VGA) {
@@ -5043,9 +4986,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        xf86SetGamma(pScrn, zeros);
     }
 
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (pSiS->SecondHead)) {
-#endif
        xf86DrvMsg(pScrn->scrnIndex, pSiS->CRT1gammaGiven ? X_CONFIG : X_INFO,
 	     "%samma correction is %s\n",
 	     (pSiS->VBFlags2 & VB2_VIDEOBRIDGE) ? "CRT1 g" : "G",
@@ -5071,17 +5012,11 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     }
 	  }
        }
-#ifdef SISDUALHEAD
     }
-#endif
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) pSiS->CRT2SepGamma = FALSE;
-#endif
 
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead))
-#endif
     {
        Bool isDH = FALSE;
        if(pSiS->CRT2gamma) {
@@ -5133,13 +5068,9 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        usScratchCR32 = pSiS->postVBCR32;
        if(pSiS->VESA != 1) {
           /* Copy forceCRT1 option to CRT1off if option is given */
-#ifdef SISDUALHEAD
           /* In DHM, handle this option only for master head, not the slave */
           if( (pSiS->forceCRT1 != -1) &&
 	       (!(pSiS->DualHeadMode && pSiS->SecondHead)) ) {
-#else
-          if(pSiS->forceCRT1 != -1) {
-#endif
 	     xf86DrvMsg(pScrn->scrnIndex, X_CONFIG,
 		 "CRT1 detection overruled by ForceCRT1 option\n");
 	     if(pSiS->forceCRT1) {
@@ -5325,14 +5256,12 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
      */
     if(pSiS->VBFlags & DISPTYPE_DISP2) {
         if(pSiS->CRT1off) {	/* CRT2 only ------------------------------- */
-#ifdef SISDUALHEAD
 	     if(pSiS->DualHeadMode) {
 		SISErrorLog(pScrn,
 		    "CRT1 not detected or forced off. Dual Head mode can't initialize.\n");
 		if(pSiSEnt) pSiSEnt->DisableDual = TRUE;
 		goto my_error_1;
 	     }
-#endif
 	     if(pSiS->MergedFB) {
 		if(pSiS->MergedFBAuto) {
 		   xf86DrvMsg(pScrn->scrnIndex, X_INFO, mergednocrt1, mergeddisstr);
@@ -5347,7 +5276,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     /* No CRT1? Then we use the video overlay on CRT2 */
 	     pSiS->XvOnCRT2 = TRUE;
 	} else			/* CRT1 and CRT2 - mirror or dual head ----- */
-#ifdef SISDUALHEAD
 	     if(pSiS->DualHeadMode) {
 		pSiS->VBFlags |= (VB_DISPMODE_DUAL | DISPTYPE_CRT1);
 		if(pSiS->VESA != -1) {
@@ -5357,7 +5285,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 		if(pSiSEnt) pSiSEnt->DisableDual = FALSE;
 		pSiS->VESA = 0;
 	     } else
-#endif
 		    if(pSiS->MergedFB) {
 		 pSiS->VBFlags |= (VB_DISPMODE_MIRROR | DISPTYPE_CRT1);
 		 if(pSiS->VESA != -1) {
@@ -5368,14 +5295,12 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     } else
 		 pSiS->VBFlags |= (VB_DISPMODE_MIRROR | DISPTYPE_CRT1);
     } else {			/* CRT1 only ------------------------------- */
-#ifdef SISDUALHEAD
 	     if(pSiS->DualHeadMode) {
 		SISErrorLog(pScrn,
 		   "No CRT2 output selected or no bridge detected. "
 		   "Dual Head mode can't initialize.\n");
 		goto my_error_1;
 	     }
-#endif
 	     if(pSiS->MergedFB) {
 		if(pSiS->MergedFBAuto) {
 		   xf86DrvMsg(pScrn->scrnIndex, X_INFO, mergednocrt2, mergeddisstr);
@@ -5415,9 +5340,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
     }
 
     /* Find out about paneldelaycompensation and evaluate option */
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead)) {
-#endif
        if(pSiS->VGAEngine == SIS_300_VGA) {
 
           if(pSiS->VBFlags2 & (VB2_LVDS | VB2_30xBDH)) {
@@ -5617,10 +5540,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	  }
 
        } /* SIS_315_VGA */
-#ifdef SISDUALHEAD
     }
-#endif
-
 
     /* In dual head mode, both heads (currently) share the maxxfbmem equally.
      * If memory sharing is done differently, the following has to be changed;
@@ -5633,7 +5553,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
     pSiS->dhmOffset = pSiS->FbBaseOffset;
     pSiS->FbAddress += pSiS->dhmOffset;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        pSiS->FbAddress = pSiS->realFbAddress;
        if(!pSiS->SecondHead) {
@@ -5658,7 +5577,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     pSiS->maxxfbmem/1024,  pSiS->FbAddress);
        }
     }
-#endif
 
     /* Note: Do not use availMem for anything from now. Use
      * maxxfbmem instead. (availMem does not take dual head
@@ -5675,11 +5593,9 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        pSiS->DRIheapstart = pSiS->maxxfbmem;
        pSiS->DRIheapend = pSiS->availMem;
     }
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        pSiS->DRIheapstart = pSiS->DRIheapend = 0;
     } else
-#endif
            if(pSiS->DRIheapstart >= pSiS->DRIheapend) {
 #if 0  /* For future use */
        xf86DrvMsg(pScrn->scrnIndex, X_INFO,
@@ -5716,12 +5632,10 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        }
     }
 
-#ifdef SISDUALHEAD
     /* In dual head mode, probe DDC using VBE only for CRT1 (second head) */
     if((pSiS->DualHeadMode) && (!didddc2) && (!pSiS->SecondHead)) {
        didddc2 = TRUE;
     }
-#endif
 
     if(!didddc2) {
        /* If CRT1 is off or LCDA, skip DDC via VBE */
@@ -5819,7 +5733,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
     /* Copy our detected monitor gammas, part 1. Note that device redetection
      * is not supported in DHM, so there is no need to do that anytime later.
      */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(!pSiS->SecondHead) {
           /* CRT2: Got gamma for LCD or VGA2 */
@@ -5830,7 +5743,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        }
        if(pSiS->CRT2LCDMonitorGamma) pSiSEnt->CRT2LCDMonitorGamma = pSiS->CRT2LCDMonitorGamma;
     }
-#endif
 
     /* end of DDC */
 
@@ -5900,7 +5812,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     acceptcustommodes = FALSE;
 	     includelcdmodes   = FALSE;
 	  }
-#ifdef SISDUALHEAD  /* Dual head is static. Output devices will not change. */
+          /* Dual head is static. Output devices will not change. */
 	  if(pSiS->DualHeadMode) {
 	     if(!pSiS->SecondHead) {  /* CRT2: */
 	        if(pSiS->VBFlags2 & VB2_SISTMDSBRIDGE) {
@@ -5936,7 +5848,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 		}
 	     }
 	  } else
-#endif
           /* MergedFB mode is not static. Output devices may change. */
           if(pSiS->MergedFB) {
 	     if(pSiS->VBFlags & CRT1_LCDA) {
@@ -6079,9 +5990,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	  SiSSetSyncRangeFromEdid(pScrn, 1);
 	  if(pScrn->monitor->nHsync > 0) {
 	     xf86DrvMsg(pScrn->scrnIndex, X_INFO, subshstr,
-#ifdef SISDUALHEAD
 			pSiS->DualHeadMode ? (pSiS->SecondHead ? 1 : 2) :
-#endif
 				pSiS->CRT1off ? 2 : 1);
 	     fromDDC = TRUE;
 	  }
@@ -6095,9 +6004,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     if((crt1freqoverruled = CheckAndOverruleH(pScrn, pScrn->monitor))) {
 		xf86DrvMsg(pScrn->scrnIndex, X_INFO, saneh,
 			HaveNoRanges ? "missing" : "bogus",
-#ifdef SISDUALHEAD
 			pSiS->DualHeadMode ? (pSiS->SecondHead ? 1 : 2) :
-#endif
 				pSiS->CRT1off ? 2 : 1);
 	     }
 	  }
@@ -6110,9 +6017,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	  SiSSetSyncRangeFromEdid(pScrn, 0);
 	  if(pScrn->monitor->nVrefresh > 0) {
 	     xf86DrvMsg(pScrn->scrnIndex, X_INFO, subsvstr,
-#ifdef SISDUALHEAD
 			pSiS->DualHeadMode ? (pSiS->SecondHead ? 1 : 2) :
-#endif
 				pSiS->CRT1off ? 2 : 1);
 	     fromDDC = TRUE;
           }
@@ -6124,9 +6029,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     if((crt1freqoverruled = CheckAndOverruleV(pScrn, pScrn->monitor))) {
 		xf86DrvMsg(pScrn->scrnIndex, X_INFO, sanev,
 			HaveNoRanges ? "missing" : "bogus",
-#ifdef SISDUALHEAD
 			pSiS->DualHeadMode ? (pSiS->SecondHead ? 1 : 2) :
-#endif
 				pSiS->CRT1off ? 2 : 1);
 	     }
 	  }
@@ -6214,7 +6117,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
      *    which are unsuitable for dual head mode.
      * -) Find the highest used pixelclock on the master head.
      */
-#ifdef SISDUALHEAD
     if((pSiS->DualHeadMode) && (!pSiS->SecondHead)) {
 
        pSiSEnt->maxUsedClock = 0;
@@ -6251,7 +6153,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 
        }
     }
-#endif
 
     /* Prune the modes marked as invalid */
     xf86PruneDriverModes(pScrn);
@@ -6279,7 +6180,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
     {
        Bool usemyprint = FALSE;
 
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode) {
 	  if(pSiS->SecondHead) {
 	     if(pSiS->VBFlags & CRT1_LCDA) usemyprint = TRUE;
@@ -6287,7 +6187,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     if(pSiS->VBFlags & (CRT2_LCD | CRT2_TV)) usemyprint = TRUE;
 	  }
        } else
-#endif
        if(pSiS->MergedFB) {
 	  if(pSiS->VBFlags & CRT1_LCDA) usemyprint = TRUE;
        } else
@@ -6609,9 +6508,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        pSiS->pVbe = NULL;
     }
 
-#ifdef SISDUALHEAD
     xf86SetPrimInitDone(pScrn->entityList[0]);
-#endif
 
     if(pSiS->pInt) xf86FreeInt10(pSiS->pInt);
     pSiS->pInt = NULL;
@@ -6620,7 +6517,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
        pSiS->SiS_SD_Flags |= SiS_SD_SUPPORTXVGAMMA1;
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
 	pSiS->SiS_SD_Flags |= SiS_SD_ISDUALHEAD;
 	if(pSiS->SecondHead) pSiS->SiS_SD_Flags |= SiS_SD_ISDHSECONDHEAD;
@@ -6632,7 +6528,6 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	}
 #endif
     }
-#endif
 
     if(pSiS->MergedFB) pSiS->SiS_SD_Flags |= SiS_SD_ISMERGEDFB;
 
@@ -6680,9 +6575,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 
 my_error_1:
 my_error_0:
-#ifdef SISDUALHEAD
     if(pSiSEnt) pSiSEnt->ErrorAfterFirst = TRUE;
-#endif
     if(pSiS->pInt) xf86FreeInt10(pSiS->pInt);
     pSiS->pInt = NULL;
     SISFreeRec(pScrn);
@@ -6697,16 +6590,13 @@ static Bool
 SISMapMem(ScrnInfoPtr pScrn)
 {
     SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
     /*
      * Map IO registers to virtual address space
      * (For Alpha, we need to map SPARSE memory, since we need
      * byte/short access.)
      */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
         pSiSEnt->MapCountIOBase++;
         if(!(pSiSEnt->IOBase)) {
@@ -6726,7 +6616,6 @@ SISMapMem(ScrnInfoPtr pScrn)
         }
         pSiS->IOBase = pSiSEnt->IOBase;
     } else
-#endif
        {
 	     void **result = (void **)&pSiS->IOBase;
 	     int err = pci_device_map_range(pSiS->PciInfo,
@@ -6752,7 +6641,6 @@ SISMapMem(ScrnInfoPtr pScrn)
      * for Alpha, we need to map DENSE memory as well, for
      * setting CPUToScreenColorExpandBase.
      */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
         pSiSEnt->MapCountIOBaseDense++;
         if(!(pSiSEnt->IOBaseDense)) {
@@ -6772,7 +6660,6 @@ SISMapMem(ScrnInfoPtr pScrn)
 	}
 	pSiS->IOBaseDense = pSiSEnt->IOBaseDense;
     } else {
-#endif /* SISDUALHEAD */
 	     void **result = (void **)&pSiS->IOBaseDense;
 	     int err = pci_device_map_range(pSiS->PciInfo,
  	                                    pSiS->IOAddress,
@@ -6785,16 +6672,13 @@ SISMapMem(ScrnInfoPtr pScrn)
                              "Unable to map IO dense aperture. %s (%d)\n",
                              strerror (err), err);
 	     }
-#ifdef SISDUALHEAD
     }
-#endif
     if(pSiS->IOBaseDense == NULL) {
        SISErrorLog(pScrn, "Could not map MMIO dense area\n");
        return FALSE;
     }
 #endif /* __alpha__ */
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
 	pSiSEnt->MapCountFbBase++;
 	if(!(pSiSEnt->FbBase)) {
@@ -6817,7 +6701,6 @@ SISMapMem(ScrnInfoPtr pScrn)
 	/* Adapt FbBase (for DHM and SiS76x UMA skipping; dhmOffset is 0 otherwise) */
 	pSiS->FbBase += pSiS->dhmOffset;
     } else {
-#endif
 
          int err = pci_device_map_range(pSiS->PciInfo,
                                    (ULong)pSiS->realFbAddress,
@@ -6834,9 +6717,7 @@ SISMapMem(ScrnInfoPtr pScrn)
 	pSiS->RealFbBase = pSiS->FbBase;
 	pSiS->FbBase += pSiS->dhmOffset;
 
-#ifdef SISDUALHEAD
     }
-#endif
 
     if(pSiS->FbBase == NULL) {
        SISErrorLog(pScrn, "Could not map framebuffer area\n");
@@ -6859,14 +6740,11 @@ static Bool
 SISUnmapMem(ScrnInfoPtr pScrn)
 {
     SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
 /* In dual head mode, we must not unmap if the other head still
  * assumes memory as mapped
  */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
         if(pSiSEnt->MapCountIOBase) {
 	    pSiSEnt->MapCountIOBase--;
@@ -6902,7 +6780,6 @@ SISUnmapMem(ScrnInfoPtr pScrn)
 	    pSiS->FbBase = pSiS->RealFbBase = NULL;
 	}
     } else {
-#endif
 	pci_device_unmap_range(pSiS->PciInfo, pSiS->IOBase, (pSiS->mmioSize * 1024));
 	pSiS->IOBase = NULL;
 #ifdef __alpha__
@@ -6911,9 +6788,7 @@ SISUnmapMem(ScrnInfoPtr pScrn)
 #endif
 	pci_device_unmap_range(pSiS->PciInfo, pSiS->RealFbBase, pSiS->FbMapSize);
 	pSiS->FbBase = pSiS->RealFbBase = NULL;
-#ifdef SISDUALHEAD
     }
-#endif
     return TRUE;
 }
 
@@ -6927,10 +6802,8 @@ SISSave(ScrnInfoPtr pScrn)
     SISRegPtr sisReg;
     int flags;
 
-#ifdef SISDUALHEAD
     /* We always save master & slave */
     if(pSiS->DualHeadMode && pSiS->SecondHead) return;
-#endif
 
     sisReg = &pSiS->SavedReg;
 
@@ -7035,9 +6908,7 @@ SISModeInit(ScrnInfoPtr pScrn, DisplayModePtr mode)
 {
     SISPtr pSiS = SISPTR(pScrn);
     SISRegPtr sisReg;
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = NULL;
-#endif
 
     andSISIDXREG(SISCR,0x11,0x7f);	/* Unlock CRTC registers */
 
@@ -7049,10 +6920,8 @@ SISModeInit(ScrnInfoPtr pScrn, DisplayModePtr mode)
 
     if(pSiS->UseVESA) {  /* With VESA: */
 
-#ifdef SISDUALHEAD
        /* No dual head mode when using VESA */
        if(pSiS->SecondHead) return TRUE;
-#endif
 
        pScrn->vtSema = TRUE;
 
@@ -7092,7 +6961,6 @@ SISModeInit(ScrnInfoPtr pScrn, DisplayModePtr mode)
 
     } else { /* Without VESA: */
 
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode) {
 
 	  if(!(*pSiS->ModeInit)(pScrn, mode)) {
@@ -7133,7 +7001,6 @@ SISModeInit(ScrnInfoPtr pScrn, DisplayModePtr mode)
 	  }
 
        } else {
-#endif
 
 	  if(pSiS->VGAEngine == SIS_300_VGA || pSiS->VGAEngine == SIS_315_VGA) {
 
@@ -7248,9 +7115,7 @@ SISModeInit(ScrnInfoPtr pScrn, DisplayModePtr mode)
 
 	  }
 
-#ifdef SISDUALHEAD
        }
-#endif
     }
 
     /* Update Currentlayout */
@@ -7427,10 +7292,8 @@ SISRestore(ScrnInfoPtr pScrn)
 
     if((pSiS->VGAEngine == SIS_300_VGA) || (pSiS->VGAEngine == SIS_315_VGA)) {
 
-#ifdef SISDUALHEAD
        /* We always restore master AND slave */
        if(pSiS->DualHeadMode && pSiS->SecondHead) return;
-#endif
 
        sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
 
@@ -7703,10 +7566,8 @@ SISBridgeRestore(ScrnInfoPtr pScrn)
 {
     SISPtr pSiS = SISPTR(pScrn);
 
-#ifdef SISDUALHEAD
     /* We only restore for master head */
     if(pSiS->DualHeadMode && pSiS->SecondHead) return;
-#endif
 
     if(pSiS->VGAEngine == SIS_300_VGA || pSiS->VGAEngine == SIS_315_VGA) {
 	SiSRestoreBridge(pScrn, &pSiS->SavedReg);
@@ -7724,7 +7585,6 @@ SISBlockHandler(ScreenPtr pScreen, void *pTimeout)
     (*pScreen->BlockHandler) (pScreen, pTimeout);
     pScreen->BlockHandler = SISBlockHandler;
 
-#ifdef SISDUALHEAD
     if(pSiS->NeedCopyFastVidCpy) {
        SISEntPtr pSiSEnt = pSiS->entityPrivate;
        if(pSiSEnt->HaveFastVidCpy) {
@@ -7735,7 +7595,6 @@ SISBlockHandler(ScreenPtr pScreen, void *pTimeout)
 	  pSiS->SiSFastMemCopyFrom = pSiSEnt->SiSFastMemCopyFrom;
        }
     }
-#endif
 
     if(pSiS->VideoTimerCallback) {
        (*pSiS->VideoTimerCallback)(pScrn, currentTime.milliseconds);
@@ -7815,7 +7674,6 @@ SISSaveScreen(ScreenPtr pScreen, int mode)
     return TRUE;
 }
 
-#ifdef SISDUALHEAD
 /* SaveScreen for dual head mode */
 static Bool
 SISSaveScreenDH(ScreenPtr pScreen, int mode)
@@ -7851,7 +7709,6 @@ SISSaveScreenDH(ScreenPtr pScreen, int mode)
     }
     return TRUE;
 }
-#endif
 
 static void
 SISDisplayPowerManagementSet(ScrnInfoPtr pScrn, int PowerManagementMode, int flags)
@@ -7866,12 +7723,10 @@ SISDisplayPowerManagementSet(ScrnInfoPtr pScrn, int PowerManagementMode, int fla
     xf86DrvMsgVerb(pScrn->scrnIndex, X_INFO, 4,
           "SISDisplayPowerManagementSet(%d)\n", PowerManagementMode);
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiS->SecondHead) docrt2 = FALSE;
        else                 docrt1 = FALSE;
     }
-#endif
 
     /* FIXME: in old servers, DPMSSet was supposed to be called without open
      * the correct PCI bridges before access the hardware. Now we have this
@@ -8016,24 +7871,16 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
     ULong OnScreenSize;
     int ret, height, width, displayWidth;
     UChar *FBStart;
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = NULL;
-#endif
 
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead)) {
-#endif
        SiS_LoadInitVBE(pScrn);
-#ifdef SISDUALHEAD
     }
-#endif
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        pSiSEnt = pSiS->entityPrivate;
        pSiSEnt->refCount++;
     }
-#endif
 
 #ifdef SIS_PC_PLATFORM
     /* Map 64k VGA window for saving/restoring CGA fonts */
@@ -8111,12 +7958,10 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
 	     pSiS->OldMode = myoldmode;
 	  }
        }
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode) {
           if(!pSiS->SecondHead) pSiSEnt->OldMode = pSiS->OldMode;
           else                  pSiS->OldMode = pSiSEnt->OldMode;
        }
-#endif
     }
 
     /* RandR resets screen mode and size in CloseScreen(), hence
@@ -8131,7 +7976,6 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
     /* Copy our detected monitor gammas, part 2. Note that device redetection
      * is not supported in DHM, so there is no need to do that anytime later.
      */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(!pSiS->SecondHead) {
           /* CRT2 */
@@ -8142,7 +7986,6 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
        }
        if(!pSiS->CRT2LCDMonitorGamma) pSiS->CRT2LCDMonitorGamma = pSiSEnt->CRT2LCDMonitorGamma;
     }
-#endif
 
     /* Initialize the first mode */
     if(!SISModeInit(pScrn, pScrn->currentMode)) {
@@ -8209,25 +8052,21 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
      * For 315/330 series, this is done in EnableTurboQueue
      * which has already been called during ModeInit().
      */
-#ifdef SISDUALHEAD
     if(pSiS->SecondHead)
        pSiS->cmdQueueLenPtr = &(SISPTR(pSiSEnt->pScrn_1)->cmdQueueLen);
     else
-#endif
        pSiS->cmdQueueLenPtr = &(pSiS->cmdQueueLen);
 
     pSiS->cmdQueueLen = 0; /* Force an EngineIdle() at start */
 
 #ifdef SISDRI
     if(pSiS->loadDRI) {
-#ifdef SISDUALHEAD
        /* No DRI in dual head mode */
        if(pSiS->DualHeadMode) {
 	  pSiS->directRenderingEnabled = FALSE;
 	  xf86DrvMsg(pScrn->scrnIndex, X_INFO,
 		"DRI not supported in Dual Head mode\n");
        } else
-#endif
 	      if(pSiS->VGAEngine != SIS_315_VGA) {
 	  /* Force the initialization of the context */
 	  pSiS->directRenderingEnabled = SISDRIScreenInit(pScreen);
@@ -8311,7 +8150,6 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
     /* Dual head: Do this AFTER the mode for CRT1 has been set */
     pSiS->NeedCopyFastVidCpy = FALSE;
     if(!pSiS->SiSFastVidCopyDone) {
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode) {
 	  if(pSiS->SecondHead) {
 	     pSiSEnt->SiSFastVidCopy = SiSVidCopyInit(pScreen, &pSiSEnt->SiSFastMemCopy, FALSE);
@@ -8331,7 +8169,6 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
 	     pSiS->NeedCopyFastVidCpy = TRUE;
 	  }
        } else {
-#endif
 	  pSiS->SiSFastVidCopy = SiSVidCopyInit(pScreen, &pSiS->SiSFastMemCopy, FALSE);
 	  pSiS->SiSFastVidCopyFrom = SiSVidCopyGetDefault();
 	  pSiS->SiSFastMemCopyFrom = SiSVidCopyGetDefault();
@@ -8340,9 +8177,7 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
 	     pSiS->SiSFastVidCopyFrom = SiSVidCopyInit(pScreen, &pSiS->SiSFastMemCopyFrom, TRUE);
 	  }
 #endif /* EXA */
-#ifdef SISDUALHEAD
        }
-#endif
     }
     pSiS->SiSFastVidCopyDone = TRUE;
 
@@ -8356,9 +8191,7 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
        SiSHWCursorInit(pScreen);
     }
 
-#ifdef SISDUALHEAD
     if(!pSiS->DualHeadMode) {
-#endif
        if((pSiS->VBFlags2 & VB2_SISBRIDGE) && (pScrn->depth > 8)) {
 
 	  pSiS->CRT2ColNum = 1 << pScrn->rgbBits;
@@ -8384,9 +8217,7 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
 	  }
 
        }
-#ifdef SISDUALHEAD
     } else pSiS->CRT2SepGamma = FALSE;
-#endif
 
     /* Initialise default colormap */
     if(!miCreateDefColormap(pScreen)) {
@@ -8472,7 +8303,6 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
 
 	  const char *using = "Using SiS300/315/330/340 series HW Xv";
 
-#ifdef SISDUALHEAD
 	  if(pSiS->DualHeadMode) {
 	     xf86DrvMsg(pScrn->scrnIndex, X_INFO,
 		    "%s on CRT%d\n", using, (pSiS->SecondHead ? 1 : 2));
@@ -8485,16 +8315,13 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
 		}
 	     }
 	  } else {
-#endif
 	     if(pSiS->hasTwoOverlays) {
 		xf86DrvMsg(pScrn->scrnIndex, X_INFO, "%s\n", using);
 	     } else {
 		xf86DrvMsg(pScrn->scrnIndex, X_INFO, "%s by default on CRT%d\n",
 			using, (pSiS->XvOnCRT2 ? 2 : 1));
 	     }
-#ifdef SISDUALHEAD
 	  }
-#endif
 
 	  SISInitVideo(pScreen);
 
@@ -8577,11 +8404,9 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
     /* Wrap CloseScreen and set up SaveScreen */
     pSiS->CloseScreen = pScreen->CloseScreen;
     pScreen->CloseScreen = SISCloseScreen;
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode)
        pScreen->SaveScreen = SISSaveScreenDH;
     else
-#endif
        pScreen->SaveScreen = SISSaveScreen;
 
     /* Install BlockHandler */
@@ -8606,7 +8431,6 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
 
     /* Turn on the screen now */
     /* We do this in dual head mode after second head is finished */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiS->SecondHead) {
 	  sisclearvram(pSiS->FbBase, OnScreenSize);
@@ -8617,25 +8441,18 @@ SISScreenInit(ScreenPtr pScreen, int argc, char **argv)
 	  pSiSEnt->OnScreenSize1 = OnScreenSize;
        }
     } else {
-#endif
        SISSaveScreen(pScreen, SCREEN_SAVER_OFF);
        sisclearvram(pSiS->FbBase, OnScreenSize);
-#ifdef SISDUALHEAD
     }
-#endif
 
     pSiS->SiS_SD_Flags &= ~SiS_SD_SUPPORTSGRCRT2;
-#ifdef SISDUALHEAD
     if(!pSiS->DualHeadMode) {
-#endif
        if(pSiS->VBFlags2 & VB2_SISBRIDGE) {
           if((pSiS->crt2cindices) && (pSiS->crt2gcolortable)) {
              pSiS->SiS_SD_Flags |= SiS_SD_SUPPORTSGRCRT2;
 	  }
        }
-#ifdef SISDUALHEAD
     }
-#endif
 
     pSiS->SiS_SD_Flags &= ~SiS_SD_ISDEPTH8;
     if(pSiS->CurrentLayout.bitsPerPixel == 8) {
@@ -9158,7 +8975,6 @@ SISAdjustFrame(ScrnInfoPtr pScrn, int x, int y)
     			x, y, pSiS->CurrentLayout.bitsPerPixel, pSiS->CurrentLayout.displayWidth, base, pSiS->dhmOffset);
 #endif
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(!pSiS->SecondHead) {
 	  /* Head 1 (master) is always CRT2 */
@@ -9168,7 +8984,6 @@ SISAdjustFrame(ScrnInfoPtr pScrn, int x, int y)
 	  SISSetStartAddressCRT1(pSiS, base);
        }
     } else {
-#endif
        switch(pSiS->VGAEngine) {
 	  case SIS_300_VGA:
 	  case SIS_315_VGA:
@@ -9192,10 +9007,7 @@ SISAdjustFrame(ScrnInfoPtr pScrn, int x, int y)
 	     /* Eventually lock CRTC registers */
 	     setSISIDXREG(SISCR, 0x11, 0x7F, (cr11backup & 0x80));
        }
-#ifdef SISDUALHEAD
     }
-#endif
-
 }
 
 /*
@@ -9231,9 +9043,7 @@ SISEnterVT(ScrnInfoPtr pScrn)
     }
 #endif
 
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead))
-#endif
        if(pSiS->ResetXv) {
           (pSiS->ResetXv)(pScrn);
        }
@@ -9259,12 +9069,9 @@ SISLeaveVT(ScrnInfoPtr pScrn)
     }
 #endif
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode && pSiS->SecondHead) return;
-#endif
 
     if(pSiS->CursorInfoPtr) {
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode) {
           if(!pSiS->SecondHead) {
 	     pSiS->ForceCursorOff = TRUE;
@@ -9273,12 +9080,9 @@ SISLeaveVT(ScrnInfoPtr pScrn)
 	     pSiS->ForceCursorOff = FALSE;
 	  }
        } else {
-#endif
           pSiS->CursorInfoPtr->HideCursor(pScrn);
           SISWaitVBRetrace(pScrn);
-#ifdef SISDUALHEAD
        }
-#endif
     }
 
     SISBridgeRestore(pScrn);
@@ -9326,9 +9130,7 @@ SISCloseScreen(ScreenPtr pScreen)
 {
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
     if(pSiS->SiSCtrlExtEntry) {
        SiSCtrlExtUnregister(pSiS, pScrn->scrnIndex);
@@ -9344,7 +9146,6 @@ SISCloseScreen(ScreenPtr pScreen)
     if(pScrn->vtSema) {
 
         if(pSiS->CursorInfoPtr) {
-#ifdef SISDUALHEAD
            if(pSiS->DualHeadMode) {
               if(!pSiS->SecondHead) {
 	         pSiS->ForceCursorOff = TRUE;
@@ -9353,12 +9154,9 @@ SISCloseScreen(ScreenPtr pScreen)
 	         pSiS->ForceCursorOff = FALSE;
 	      }
            } else {
-#endif
              pSiS->CursorInfoPtr->HideCursor(pScrn);
              SISWaitVBRetrace(pScrn);
-#ifdef SISDUALHEAD
            }
-#endif
 	}
 
         SISBridgeRestore(pScrn);
@@ -9399,12 +9197,10 @@ SISCloseScreen(ScreenPtr pScreen)
     SiSVGAUnmapMem(pScrn);
 #endif
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        pSiSEnt = pSiS->entityPrivate;
        pSiSEnt->refCount--;
     }
-#endif
 
     if(pSiS->pInt) {
        xf86FreeInt10(pSiS->pInt);
@@ -9482,7 +9278,6 @@ SISValidMode(ScrnInfoPtr pScrn, DisplayModePtr mode, Bool verbose, int flags)
     }
 
     if(pSiS->VGAEngine == SIS_300_VGA || pSiS->VGAEngine == SIS_315_VGA) {
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode) {
           if(pSiS->SecondHead) {
 	     if(SiS_CheckModeCRT1(pScrn, mode, pSiS->VBFlags, pSiS->HaveCustomModes) < 0x14)
@@ -9492,7 +9287,6 @@ SISValidMode(ScrnInfoPtr pScrn, DisplayModePtr mode, Bool verbose, int flags)
 	        return(MODE_BAD);
 	  }
        } else
-#endif
        if(pSiS->MergedFB) {
 	  if(!mode->Private) {
 	     if(!pSiS->CheckForCRT2) {
@@ -9637,12 +9431,10 @@ SiSEnableTurboQueue(ScrnInfoPtr pScrn)
 	      SIS_MMIO_OUT32(pSiS->IOBase, 0x85c4, (CARD32)(*(pSiS->cmdQ_SharedWritePort)));
 	      SIS_MMIO_OUT32(pSiS->IOBase, 0x85C0, pSiS->cmdQueueOffset);
 	      temp = (ULong)pSiS->RealFbBase;
-#ifdef SISDUALHEAD
 	      if(pSiS->DualHeadMode) {
 	         SISEntPtr pSiSEnt = pSiS->entityPrivate;
 	         temp = (ULong)pSiSEnt->RealFbBase;
 	      }
-#endif
 	      temp += pSiS->cmdQueueOffset;
 	      pSiS->cmdQueueBase = (unsigned int *)temp;
 	      outSISIDXREG(SISCR, 0x55, tempCR55);
@@ -10072,14 +9864,10 @@ void SiSPreSetMode(ScrnInfoPtr pScrn, DisplayModePtr mode, int viewmode)
 void SiS_SetCHTVlumabandwidthcvbs(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->chtvlumabandwidthcvbs = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->chtvlumabandwidthcvbs = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_CHRONTEL)) return;
@@ -10105,16 +9893,12 @@ void SiS_SetCHTVlumabandwidthcvbs(ScrnInfoPtr pScrn, int val)
 int SiS_GetCHTVlumabandwidthcvbs(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    if(!((pSiS->VBFlags2 & VB2_CHRONTEL) && (pSiS->VBFlags & CRT2_TV))) {
-#ifdef SISDUALHEAD
       if(pSiSEnt && pSiS->DualHeadMode)
            return (int)pSiSEnt->chtvlumabandwidthcvbs;
       else
-#endif
            return (int)pSiS->chtvlumabandwidthcvbs;
    } else {
       sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10132,14 +9916,10 @@ int SiS_GetCHTVlumabandwidthcvbs(ScrnInfoPtr pScrn)
 void SiS_SetCHTVlumabandwidthsvideo(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->chtvlumabandwidthsvideo = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->chtvlumabandwidthsvideo = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_CHRONTEL)) return;
@@ -10165,16 +9945,12 @@ void SiS_SetCHTVlumabandwidthsvideo(ScrnInfoPtr pScrn, int val)
 int SiS_GetCHTVlumabandwidthsvideo(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    if(!((pSiS->VBFlags2 & VB2_CHRONTEL) && (pSiS->VBFlags & CRT2_TV))) {
-#ifdef SISDUALHEAD
       if(pSiSEnt && pSiS->DualHeadMode)
            return (int)pSiSEnt->chtvlumabandwidthsvideo;
       else
-#endif
            return (int)pSiS->chtvlumabandwidthsvideo;
    } else {
       sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10192,14 +9968,10 @@ int SiS_GetCHTVlumabandwidthsvideo(ScrnInfoPtr pScrn)
 void SiS_SetCHTVlumaflickerfilter(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->chtvlumaflickerfilter = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->chtvlumaflickerfilter = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_CHRONTEL)) return;
@@ -10228,16 +10000,12 @@ void SiS_SetCHTVlumaflickerfilter(ScrnInfoPtr pScrn, int val)
 int SiS_GetCHTVlumaflickerfilter(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    if(!((pSiS->VBFlags2 & VB2_CHRONTEL) && (pSiS->VBFlags & CRT2_TV))) {
-#ifdef SISDUALHEAD
       if(pSiSEnt && pSiS->DualHeadMode)
           return (int)pSiSEnt->chtvlumaflickerfilter;
       else
-#endif
           return (int)pSiS->chtvlumaflickerfilter;
    } else {
       sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10255,14 +10023,10 @@ int SiS_GetCHTVlumaflickerfilter(ScrnInfoPtr pScrn)
 void SiS_SetCHTVchromabandwidth(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->chtvchromabandwidth = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->chtvchromabandwidth = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_CHRONTEL)) return;
@@ -10288,16 +10052,12 @@ void SiS_SetCHTVchromabandwidth(ScrnInfoPtr pScrn, int val)
 int SiS_GetCHTVchromabandwidth(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    if(!((pSiS->VBFlags2 & VB2_CHRONTEL) && (pSiS->VBFlags & CRT2_TV))) {
-#ifdef SISDUALHEAD
       if(pSiSEnt && pSiS->DualHeadMode)
            return (int)pSiSEnt->chtvchromabandwidth;
       else
-#endif
            return (int)pSiS->chtvchromabandwidth;
    } else {
       sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10315,14 +10075,10 @@ int SiS_GetCHTVchromabandwidth(ScrnInfoPtr pScrn)
 void SiS_SetCHTVchromaflickerfilter(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->chtvchromaflickerfilter = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->chtvchromaflickerfilter = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_CHRONTEL)) return;
@@ -10351,16 +10107,12 @@ void SiS_SetCHTVchromaflickerfilter(ScrnInfoPtr pScrn, int val)
 int SiS_GetCHTVchromaflickerfilter(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    if(!((pSiS->VBFlags2 & VB2_CHRONTEL) && (pSiS->VBFlags & CRT2_TV))) {
-#ifdef SISDUALHEAD
       if(pSiSEnt && pSiS->DualHeadMode)
            return (int)pSiSEnt->chtvchromaflickerfilter;
       else
-#endif
            return (int)pSiS->chtvchromaflickerfilter;
    } else {
       sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10378,14 +10130,10 @@ int SiS_GetCHTVchromaflickerfilter(ScrnInfoPtr pScrn)
 void SiS_SetCHTVcvbscolor(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->chtvcvbscolor = val ? 1 : 0;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->chtvcvbscolor = pSiS->chtvcvbscolor;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_CHRONTEL)) return;
@@ -10407,16 +10155,12 @@ void SiS_SetCHTVcvbscolor(ScrnInfoPtr pScrn, int val)
 int SiS_GetCHTVcvbscolor(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    if(!((pSiS->VBFlags2 & VB2_CHRONTEL) && (pSiS->VBFlags & CRT2_TV))) {
-#ifdef SISDUALHEAD
       if(pSiSEnt && pSiS->DualHeadMode)
            return (int)pSiSEnt->chtvcvbscolor;
       else
-#endif
            return (int)pSiS->chtvcvbscolor;
    } else {
       sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10434,14 +10178,10 @@ int SiS_GetCHTVcvbscolor(ScrnInfoPtr pScrn)
 void SiS_SetCHTVtextenhance(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->chtvtextenhance = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->chtvtextenhance = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_CHRONTEL)) return;
@@ -10470,16 +10210,12 @@ void SiS_SetCHTVtextenhance(ScrnInfoPtr pScrn, int val)
 int SiS_GetCHTVtextenhance(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    if(!((pSiS->VBFlags2 & VB2_CHRONTEL) && (pSiS->VBFlags & CRT2_TV))) {
-#ifdef SISDUALHEAD
       if(pSiSEnt && pSiS->DualHeadMode)
            return (int)pSiSEnt->chtvtextenhance;
       else
-#endif
            return (int)pSiS->chtvtextenhance;
    } else {
       sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10497,14 +10233,10 @@ int SiS_GetCHTVtextenhance(ScrnInfoPtr pScrn)
 void SiS_SetCHTVcontrast(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->chtvcontrast = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->chtvcontrast = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_CHRONTEL)) return;
@@ -10528,16 +10260,12 @@ void SiS_SetCHTVcontrast(ScrnInfoPtr pScrn, int val)
 int SiS_GetCHTVcontrast(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    if(!((pSiS->VBFlags2 & VB2_CHRONTEL) && (pSiS->VBFlags & CRT2_TV))) {
-#ifdef SISDUALHEAD
       if(pSiSEnt && pSiS->DualHeadMode)
            return (int)pSiSEnt->chtvcontrast;
       else
-#endif
            return (int)pSiS->chtvcontrast;
    } else {
       sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10555,14 +10283,10 @@ int SiS_GetCHTVcontrast(ScrnInfoPtr pScrn)
 void SiS_SetSISTVedgeenhance(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->sistvedgeenhance = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->sistvedgeenhance = val;
-#endif
 
    if(!(pSiS->VBFlags2 & VB2_301))  return;
    if(!(pSiS->VBFlags & CRT2_TV))   return;
@@ -10580,11 +10304,9 @@ int SiS_GetSISTVedgeenhance(ScrnInfoPtr pScrn)
    SISPtr pSiS = SISPTR(pScrn);
    int result = pSiS->sistvedgeenhance;
    UChar temp;
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode) result = pSiSEnt->sistvedgeenhance;
-#endif
 
    if(!(pSiS->VBFlags2 & VB2_301))  return result;
    if(!(pSiS->VBFlags & CRT2_TV))   return result;
@@ -10597,14 +10319,10 @@ int SiS_GetSISTVedgeenhance(ScrnInfoPtr pScrn)
 void SiS_SetSISTVantiflicker(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->sistvantiflicker = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->sistvantiflicker = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV))      return;
    if(!(pSiS->VBFlags2 & VB2_SISBRIDGE)) return;
@@ -10625,11 +10343,9 @@ int SiS_GetSISTVantiflicker(ScrnInfoPtr pScrn)
    SISPtr pSiS = SISPTR(pScrn);
    int result = pSiS->sistvantiflicker;
    UChar temp;
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode) result = pSiSEnt->sistvantiflicker;
-#endif
 
    if(!(pSiS->VBFlags2 & VB2_SISBRIDGE)) return result;
    if(!(pSiS->VBFlags & CRT2_TV))        return result;
@@ -10645,14 +10361,10 @@ int SiS_GetSISTVantiflicker(ScrnInfoPtr pScrn)
 void SiS_SetSISTVsaturation(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->sistvsaturation = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->sistvsaturation = val;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV)) return;
    if(!(pSiS->VBFlags2 & VB2_SISBRIDGE)) return;
@@ -10671,11 +10383,9 @@ int SiS_GetSISTVsaturation(ScrnInfoPtr pScrn)
    SISPtr pSiS = SISPTR(pScrn);
    int result = pSiS->sistvsaturation;
    UChar temp;
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode)  result = pSiSEnt->sistvsaturation;
-#endif
 
    if(!(pSiS->VBFlags2 & VB2_SISBRIDGE)) return result;
    if(pSiS->VBFlags2 & VB2_301)          return result;
@@ -10689,34 +10399,26 @@ int SiS_GetSISTVsaturation(ScrnInfoPtr pScrn)
 void SiS_SetSISTVcolcalib(ScrnInfoPtr pScrn, int val, Bool coarse)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
    int ccoarse, cfine, cbase = pSiS->sistvccbase;
    /* UChar temp; */
 
-#ifdef SISDUALHEAD
    if(pSiSEnt && pSiS->DualHeadMode) cbase = pSiSEnt->sistvccbase;
-#endif
 
    if(coarse) {
       pSiS->sistvcolcalibc = ccoarse = val;
       cfine = pSiS->sistvcolcalibf;
-#ifdef SISDUALHEAD
       if(pSiSEnt) {
          pSiSEnt->sistvcolcalibc = val;
 	 if(pSiS->DualHeadMode) cfine = pSiSEnt->sistvcolcalibf;
       }
-#endif
    } else {
       pSiS->sistvcolcalibf = cfine = val;
       ccoarse = pSiS->sistvcolcalibc;
-#ifdef SISDUALHEAD
       if(pSiSEnt) {
          pSiSEnt->sistvcolcalibf = val;
          if(pSiS->DualHeadMode) ccoarse = pSiSEnt->sistvcolcalibc;
       }
-#endif
    }
 
    if(!(pSiS->VBFlags & CRT2_TV))               return;
@@ -10747,14 +10449,12 @@ void SiS_SetSISTVcolcalib(ScrnInfoPtr pScrn, int val, Bool coarse)
 int SiS_GetSISTVcolcalib(ScrnInfoPtr pScrn, Bool coarse)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode)
       if(coarse)  return (int)pSiSEnt->sistvcolcalibc;
       else        return (int)pSiSEnt->sistvcolcalibf;
    else
-#endif
    if(coarse)     return (int)pSiS->sistvcolcalibc;
    else           return (int)pSiS->sistvcolcalibf;
 }
@@ -10762,14 +10462,10 @@ int SiS_GetSISTVcolcalib(ScrnInfoPtr pScrn, Bool coarse)
 void SiS_SetSISTVcfilter(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->sistvcfilter = val ? 1 : 0;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->sistvcfilter = pSiS->sistvcfilter;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV))               return;
    if(!(pSiS->VBFlags2 & VB2_SISBRIDGE))        return;
@@ -10785,11 +10481,9 @@ int SiS_GetSISTVcfilter(ScrnInfoPtr pScrn)
    SISPtr pSiS = SISPTR(pScrn);
    int result = pSiS->sistvcfilter;
    UChar temp;
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode) result = pSiSEnt->sistvcfilter;
-#endif
 
    if(!(pSiS->VBFlags2 & VB2_SISBRIDGE))        return result;
    if(!(pSiS->VBFlags & CRT2_TV))               return result;
@@ -10803,16 +10497,12 @@ int SiS_GetSISTVcfilter(ScrnInfoPtr pScrn)
 void SiS_SetSISTVyfilter(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
    UChar p35,p36,p37,p38,p48,p49,p4a,p30;
    int i,j;
 
    pSiS->sistvyfilter = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->sistvyfilter = pSiS->sistvyfilter;
-#endif
 
    if(!(pSiS->VBFlags & CRT2_TV))               return;
    if(!(pSiS->VBFlags2 & VB2_SISBRIDGE))        return;
@@ -10822,14 +10512,12 @@ void SiS_SetSISTVyfilter(ScrnInfoPtr pScrn, int val)
    p37 = pSiS->p2_37; p38 = pSiS->p2_38;
    p48 = pSiS->p2_48; p49 = pSiS->p2_49;
    p4a = pSiS->p2_4a; p30 = pSiS->p2_30;
-#ifdef SISDUALHEAD
    if(pSiSEnt && pSiS->DualHeadMode) {
       p35 = pSiSEnt->p2_35; p36 = pSiSEnt->p2_36;
       p37 = pSiSEnt->p2_37; p38 = pSiSEnt->p2_38;
       p48 = pSiSEnt->p2_48; p49 = pSiSEnt->p2_49;
       p4a = pSiSEnt->p2_4a; p30 = pSiSEnt->p2_30;
    }
-#endif
    p30 &= 0x20;
 
    sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
@@ -10935,13 +10623,11 @@ void SiS_SetSISTVyfilter(ScrnInfoPtr pScrn, int val)
 int SiS_GetSISTVyfilter(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode)
       return (int)pSiSEnt->sistvyfilter;
    else
-#endif
       return (int)pSiS->sistvyfilter;
 }
 
@@ -11077,16 +10763,12 @@ int SiS_GetSIS6326TVyfilterstrong(ScrnInfoPtr pScrn)
 void SiS_SetTVxposoffset(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
 
    pSiS->tvxpos = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->tvxpos = val;
-#endif
 
    if(pSiS->VGAEngine == SIS_300_VGA || pSiS->VGAEngine == SIS_315_VGA) {
 
@@ -11095,9 +10777,7 @@ void SiS_SetTVxposoffset(ScrnInfoPtr pScrn, int val)
          if(pSiS->VBFlags2 & VB2_CHRONTEL) {
 
 	    int x = pSiS->tvx;
-#ifdef SISDUALHEAD
 	    if(pSiSEnt && pSiS->DualHeadMode) x = pSiSEnt->tvx;
-#endif
 	    switch(pSiS->ChrontelType) {
 	    case CHRONTEL_700x:
 	       if((val >= -32) && (val <= 32)) {
@@ -11125,7 +10805,6 @@ void SiS_SetTVxposoffset(ScrnInfoPtr pScrn, int val)
 		p2_2b = pSiS->p2_2b;
 		p2_42 = pSiS->p2_42;
 		p2_43 = pSiS->p2_43;
-#ifdef SISDUALHEAD
 	        if(pSiSEnt && pSiS->DualHeadMode) {
 		   p2_1f = pSiSEnt->p2_1f;
 		   p2_20 = pSiSEnt->p2_20;
@@ -11133,7 +10812,6 @@ void SiS_SetTVxposoffset(ScrnInfoPtr pScrn, int val)
 		   p2_42 = pSiSEnt->p2_42;
 		   p2_43 = pSiSEnt->p2_43;
 		}
-#endif
 		mult = 2;
 		if(pSiS->VBFlags & TV_YPBPR) {
 		   if(pSiS->VBFlags & (TV_YPBPR1080I | TV_YPBPR750P)) {
@@ -11212,29 +10890,23 @@ void SiS_SetTVxposoffset(ScrnInfoPtr pScrn, int val)
 int SiS_GetTVxposoffset(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode)
         return (int)pSiSEnt->tvxpos;
    else
-#endif
         return (int)pSiS->tvxpos;
 }
 
 void SiS_SetTVyposoffset(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
 
    pSiS->tvypos = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->tvypos = val;
-#endif
 
    if(pSiS->VGAEngine == SIS_300_VGA || pSiS->VGAEngine == SIS_315_VGA) {
 
@@ -11243,9 +10915,7 @@ void SiS_SetTVyposoffset(ScrnInfoPtr pScrn, int val)
          if(pSiS->VBFlags2 & VB2_CHRONTEL) {
 
 	    int y = pSiS->tvy;
-#ifdef SISDUALHEAD
 	    if(pSiSEnt && pSiS->DualHeadMode) y = pSiSEnt->tvy;
-#endif
 	    switch(pSiS->ChrontelType) {
 	    case CHRONTEL_700x:
 	       if((val >= -32) && (val <= 32)) {
@@ -11274,12 +10944,10 @@ void SiS_SetTVyposoffset(ScrnInfoPtr pScrn, int val)
 
 		p2_01 = pSiS->p2_01;
 		p2_02 = pSiS->p2_02;
-#ifdef SISDUALHEAD
 	        if(pSiSEnt && pSiS->DualHeadMode) {
 		   p2_01 = pSiSEnt->p2_01;
 		   p2_02 = pSiSEnt->p2_02;
 		}
-#endif
 		p2_01 += val; /* val * 2 */
 		p2_02 += val; /* val * 2 */
 		if(!(pSiS->VBFlags & (TV_YPBPR | TV_HIVISION))) {
@@ -11355,29 +11023,23 @@ void SiS_SetTVyposoffset(ScrnInfoPtr pScrn, int val)
 int SiS_GetTVyposoffset(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode)
         return (int)pSiSEnt->tvypos;
    else
-#endif
         return (int)pSiS->tvypos;
 }
 
 void SiS_SetTVxscale(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
 
    pSiS->tvxscale = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->tvxscale = val;
-#endif
 
    if(pSiS->VGAEngine == SIS_300_VGA || pSiS->VGAEngine == SIS_315_VGA) {
 
@@ -11391,13 +11053,11 @@ void SiS_SetTVxscale(ScrnInfoPtr pScrn, int val)
 	    p2_44 = pSiS->p2_44;
 	    p2_45 = pSiS->p2_45 & 0x3f;
 	    p2_46 = pSiS->p2_46 & 0x07;
-#ifdef SISDUALHEAD
 	    if(pSiSEnt && pSiS->DualHeadMode) {
 	       p2_44 = pSiSEnt->p2_44;
 	       p2_45 = pSiSEnt->p2_45 & 0x3f;
 	       p2_46 = pSiSEnt->p2_46 & 0x07;
 	    }
-#endif
 	    scalingfactor = (p2_46 << 13) | ((p2_45 & 0x1f) << 8) | p2_44;
 
 	    mult = 64;
@@ -11443,22 +11103,18 @@ void SiS_SetTVxscale(ScrnInfoPtr pScrn, int val)
 int SiS_GetTVxscale(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode)
         return (int)pSiSEnt->tvxscale;
    else
-#endif
         return (int)pSiS->tvxscale;
 }
 
 void SiS_SetTVyscale(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    sisSaveUnlockExtRegisterLock(pSiS, NULL, NULL);
 
@@ -11466,9 +11122,7 @@ void SiS_SetTVyscale(ScrnInfoPtr pScrn, int val)
    if(val > 3)  val = 3;
 
    pSiS->tvyscale = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->tvyscale = val;
-#endif
 
    if(pSiS->VGAEngine == SIS_300_VGA || pSiS->VGAEngine == SIS_315_VGA) {
 
@@ -11661,9 +11315,7 @@ void SiS_SetTVyscale(ScrnInfoPtr pScrn, int val)
 	    }
 	 }
 
-#ifdef SISDUALHEAD
 	 if(pSiSEnt) pSiSEnt->tvyscale = pSiS->tvyscale;
-#endif
 
 	 if(pSiS->tvyscale == 0) {
 	    UChar p2_0a = pSiS->p2_0a;
@@ -11680,7 +11332,6 @@ void SiS_SetTVyscale(ScrnInfoPtr pScrn, int val)
 	    }
 	    p2scaling = &pSiS->scalingp2[0];
 
-#ifdef SISDUALHEAD
 	    if(pSiSEnt && pSiS->DualHeadMode) {
 	       p2_0a = pSiSEnt->p2_0a;
 	       p2_2f = pSiSEnt->p2_2f;
@@ -11693,7 +11344,6 @@ void SiS_SetTVyscale(ScrnInfoPtr pScrn, int val)
 	       }
 	       p2scaling = &pSiSEnt->scalingp2[0];
 	    }
-#endif
             SISWaitRetraceCRT2(pScrn);
 	    if(pSiS->VBFlags2 & VB2_SISTAP4SCALER) {
 	       for(i = 0; i < 64; i++) {
@@ -11734,9 +11384,7 @@ void SiS_SetTVyscale(ScrnInfoPtr pScrn, int val)
 	          temp = vlimit - ((temp & 0x7f) / p1div);
 	          if((temp - (((newvde / vdediv) - 2) + 9)) > 0) break;
 	          myypos = pSiS->tvypos - 1;
-#ifdef SISDUALHEAD
 	          if(pSiSEnt && pSiS->DualHeadMode) myypos = pSiSEnt->tvypos - 1;
-#endif
 	          SiS_SetTVyposoffset(pScrn, myypos);
 	       } while(watchdog--);
 	    }
@@ -11849,27 +11497,21 @@ void SiS_SetTVyscale(ScrnInfoPtr pScrn, int val)
 int SiS_GetTVyscale(ScrnInfoPtr pScrn)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode)
         return (int)pSiSEnt->tvyscale;
    else
-#endif
         return (int)pSiS->tvyscale;
 }
 
 void SiS_SetSISCRT1SaturationGain(ScrnInfoPtr pScrn, int val)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
 
    pSiS->siscrt1satgain = val;
-#ifdef SISDUALHEAD
    if(pSiSEnt) pSiSEnt->siscrt1satgain = val;
-#endif
 
    if(!(pSiS->SiS_SD3_Flags & SiS_SD3_CRT1SATGAIN)) return;
 
@@ -11885,11 +11527,9 @@ int SiS_GetSISCRT1SaturationGain(ScrnInfoPtr pScrn)
    SISPtr pSiS = SISPTR(pScrn);
    int result = pSiS->siscrt1satgain;
    UChar temp;
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
 
    if(pSiSEnt && pSiS->DualHeadMode)  result = pSiSEnt->siscrt1satgain;
-#endif
 
    if(!(pSiS->SiS_SD3_Flags & SiS_SD3_CRT1SATGAIN)) return result;
 
@@ -11915,7 +11555,6 @@ SiSGetClockFromRegs(UChar sr2b, UChar sr2c)
    return myclock;
 }
 
-#ifdef SISDUALHEAD
 static void
 SiS_SetDHFlags(SISPtr pSiS, unsigned int misc, unsigned int sd2)
 {
@@ -11932,7 +11571,6 @@ SiS_SetDHFlags(SISPtr pSiS, unsigned int misc, unsigned int sd2)
       }
    }
 }
-#endif
 
 /* PostSetMode:
  * -) Disable CRT1 for saving bandwidth. This doesn't work with VESA;
@@ -11947,9 +11585,7 @@ static void
 SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 {
     SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
     UChar usScratchCR17, sr2b, sr2c, tmpreg;
     int   myclock1, myclock2, mycoldepth1, mycoldepth2, temp;
     Bool  flag = FALSE;
@@ -11980,9 +11616,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	 * -) If we change to a SlaveMode-Mode (like 512x384), we
 	 *    need to adapt VBFlags for eg. Xv.
 	 */
-#ifdef SISDUALHEAD
 	if(!pSiS->DualHeadMode) {
-#endif
 	   if(IsInSlaveMode) {
 	      doit = FALSE;
 	      temp = pSiS->VBFlags;
@@ -11993,9 +11627,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 		 	"VBFlags changed to 0x%0x\n", pSiS->VBFlags);
 	      }
 	   }
-#ifdef SISDUALHEAD
 	}
-#endif
 
 	if(pSiS->VGAEngine == SIS_315_VGA) {
 
@@ -12048,9 +11680,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 
     /* Set bridge to "disable CRT2" mode if CRT2 is disabled, LCD-A is enabled */
     /* (Not needed for CRT1=VGA since CRT2 will really be disabled then) */
-#ifdef SISDUALHEAD
     if(!pSiS->DualHeadMode) {
-#endif
        if((pSiS->VGAEngine == SIS_315_VGA)  && (pSiS->VBFlags2 & VB2_SISLCDABRIDGE)) {
 	  if((!pSiS->UseVESA) && (!(pSiS->VBFlags & CRT2_ENABLE)) && (pSiS->VBFlags & CRT1_LCDA)) {
 	     if(!IsInSlaveMode) {
@@ -12058,9 +11688,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	     }
 	  }
        }
-#ifdef SISDUALHEAD
     }
-#endif
 
     /* Reset flags */
     pSiS->MiscFlags &= ~( MISC_CRT1OVERLAY      |
@@ -12073,7 +11701,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 
     pSiS->SiS_SD2_Flags &= ~SiS_SD2_SIS760ONEOVL;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiSEnt->pScrn_1) {
 	  SISPTR(pSiSEnt->pScrn_1)->MiscFlags &= ~(MISC_SIS760ONEOVERLAY	|
@@ -12096,7 +11723,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	  SISPTR(pSiSEnt->pScrn_2)->SiS_SD2_Flags &= ~SiS_SD2_SIS760ONEOVL;
        }
     }
-#endif
 
     /* Determine if the video overlay can be used */
     if(!pSiS->NoXvideo) {
@@ -12236,9 +11862,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 		  }
 		  pSiS->MiscFlags |= MISC_SIS760ONEOVERLAY;
 		  pSiS->SiS_SD2_Flags |= SiS_SD2_SIS760ONEOVL;
-#ifdef SISDUALHEAD
 		  SiS_SetDHFlags(pSiS, (tmpflags | MISC_SIS760ONEOVERLAY), SiS_SD2_SIS760ONEOVL);
-#endif
 		  OverlayHandled = TRUE;
 	       }
 
@@ -12284,21 +11908,15 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
           if(myclock2 <= clklimit2) tmpflags |= MISC_CRT2OVERLAY;
           if(myclock1 <= clklimitg) tmpflags |= MISC_CRT1OVERLAYGAMMA;
 	  pSiS->MiscFlags |= tmpflags;
-#ifdef SISDUALHEAD
 	  SiS_SetDHFlags(pSiS, tmpflags, 0);
-#endif
           if(!(pSiS->MiscFlags & MISC_CRT1OVERLAY)) {
-#ifdef SISDUALHEAD
              if((!pSiS->DualHeadMode) || (pSiS->SecondHead))
-#endif
 		xf86DrvMsgVerb(pScrn->scrnIndex, X_WARNING, 3,
 		   "Current dotclock (%dMhz) too high for video overlay on CRT1\n",
 		   myclock1);
           }
           if((pSiS->VBFlags & CRT2_ENABLE) && (!(pSiS->MiscFlags & MISC_CRT2OVERLAY))) {
-#ifdef SISDUALHEAD
 	     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead))
-#endif
 		xf86DrvMsgVerb(pScrn->scrnIndex, X_WARNING, 3,
 		   "Current dotclock (%dMhz) too high for video overlay on CRT2\n",
 		   myclock2);
@@ -12325,9 +11943,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	  }
        }
        pSiS->MiscFlags |= tmpflags;
-#ifdef SISDUALHEAD
        SiS_SetDHFlags(pSiS, tmpflags, 0);
-#endif
     }
 
     /* Determine if STN is active */
@@ -12337,9 +11953,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	  tmpreg &= 0x7f;
 	  if(tmpreg == 0x5a || tmpreg == 0x5b) {
 	     pSiS->MiscFlags |= MISC_STNMODE;
-#ifdef SISDUALHEAD
 	     SiS_SetDHFlags(pSiS, MISC_STNMODE, 0);
-#endif
 	  }
        }
     }
@@ -12352,9 +11966,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	  tmpreg &= 0x7f;
 	  if((tmpreg == 0x64) || (tmpreg == 0x4a) || (tmpreg == 0x38)) {
 	     pSiS->MiscFlags |= MISC_TVNTSC1024;
-#ifdef SISDUALHEAD
 	     SiS_SetDHFlags(pSiS, MISC_TVNTSC1024, 0);
-#endif
 	  }
        }
     }
@@ -12405,7 +12017,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 
     /* Reset XV display properties (such as number of overlays, etc) */
     /* (And copy monitor gamma) */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(pSiSEnt->pScrn_1) {
 	  if(SISPTR(pSiSEnt->pScrn_1)->ResetXvDisplay) {
@@ -12422,13 +12033,10 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	  SISPTR(pSiSEnt->pScrn_2)->CRT2MonGamma = pSiS->CRT2MonGamma;
        }
     } else {
-#endif
        if(pSiS->ResetXvDisplay) {
 	  (pSiS->ResetXvDisplay)(pScrn);
        }
-#ifdef SISDUALHEAD
     }
-#endif
 
     /* Reset XV gamma correction */
     if(pSiS->ResetXvGamma) {
@@ -12438,9 +12046,7 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
     /* Reset various display parameters */
     {
        int val = pSiS->siscrt1satgain;
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode && pSiSEnt) val = pSiSEnt->siscrt1satgain;
-#endif
        SiS_SetSISCRT1SaturationGain(pScrn, val);
     }
 
@@ -12464,7 +12070,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	  int mychtvcontrast = pSiS->chtvcontrast;
 	  int mytvxpos = pSiS->tvxpos;
 	  int mytvypos = pSiS->tvypos;
-#ifdef SISDUALHEAD
 	  if(pSiSEnt && pSiS->DualHeadMode) {
 	     mychtvlumabandwidthcvbs = pSiSEnt->chtvlumabandwidthcvbs;
 	     mychtvlumabandwidthsvideo = pSiSEnt->chtvlumabandwidthsvideo;
@@ -12477,7 +12082,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	     mytvxpos = pSiSEnt->tvxpos;
 	     mytvypos = pSiSEnt->tvypos;
 	  }
-#endif
 	  if((val = mychtvlumabandwidthcvbs) != -1) {
 	     SiS_SetCHTVlumabandwidthcvbs(pScrn, val);
 	  }
@@ -12509,12 +12113,10 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	     pSiS->tvx |= (((SiS_GetCH700x(pSiS->SiS_Pr, 0x08) & 0x02) >> 1) << 8);
 	     pSiS->tvy = SiS_GetCH700x(pSiS->SiS_Pr, 0x0b);
 	     pSiS->tvy |= ((SiS_GetCH700x(pSiS->SiS_Pr, 0x08) & 0x01) << 8);
-#ifdef SISDUALHEAD
 	     if(pSiSEnt) {
 		pSiSEnt->tvx = pSiS->tvx;
 		pSiSEnt->tvy = pSiS->tvy;
 	     }
-#endif
 	     break;
 	  case CHRONTEL_701x:
 	     /* Not supported by hardware */
@@ -12529,11 +12131,9 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
        }
        if(pSiS->VBFlags2 & VB2_301) {
           int mysistvedgeenhance = pSiS->sistvedgeenhance;
-#ifdef SISDUALHEAD
           if(pSiSEnt && pSiS->DualHeadMode) {
 	     mysistvedgeenhance = pSiSEnt->sistvedgeenhance;
 	  }
-#endif
           if((val = mysistvedgeenhance) != -1) {
 	     SiS_SetSISTVedgeenhance(pScrn, val);
 	  }
@@ -12552,7 +12152,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	  int i;
 	  ULong cbase;
 	  UChar ctemp;
-#ifdef SISDUALHEAD
           if(pSiSEnt && pSiS->DualHeadMode) {
 	     mysistvantiflicker = pSiSEnt->sistvantiflicker;
 	     mysistvsaturation = pSiSEnt->sistvsaturation;
@@ -12565,7 +12164,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	     mytvxscale = pSiSEnt->tvxscale;
 	     mytvyscale = pSiSEnt->tvyscale;
 	  }
-#endif
           /* Backup default TV position, scale and colcalib registers */
 	  inSISIDXREG(SISPART2,0x1f,pSiS->p2_1f);
 	  inSISIDXREG(SISPART2,0x20,pSiS->p2_20);
@@ -12613,7 +12211,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
 	        inSISIDXREG(SISPART2,(0xc0 + i),pSiS->scalingp2[i]);
   	     }
 	  }
-#ifdef SISDUALHEAD
 	  if(pSiSEnt) {
 	     pSiSEnt->p2_1f = pSiS->p2_1f; pSiSEnt->p2_20 = pSiS->p2_20;
 	     pSiSEnt->p2_42 = pSiS->p2_42; pSiSEnt->p2_43 = pSiS->p2_43;
@@ -12639,7 +12236,6 @@ SiSPostSetMode(ScrnInfoPtr pScrn, SISRegPtr sisReg)
   	        }
 	     }
 	  }
-#endif
           if((val = mysistvantiflicker) != -1) {
 	     SiS_SetSISTVantiflicker(pScrn, val);
 	  }
@@ -12853,9 +12449,7 @@ SiS_GetModeNumber(ScrnInfoPtr pScrn, DisplayModePtr mode, unsigned int VBFlags)
    UShort i = (pSiS->CurrentLayout.bitsPerPixel+7)/8 - 1;
    BOOLEAN FSTN = pSiS->FSTN ? TRUE : FALSE;
 
-#ifdef SISDUALHEAD
    if(pSiS->DualHeadMode && pSiS->SecondHead) FSTN = FALSE;
-#endif
 
    return(SiS_GetModeID(pSiS->VGAEngine, VBFlags, mode->HDisplay, mode->VDisplay,
 			i, FSTN, pSiS->LCDwidth, pSiS->LCDheight));
@@ -13111,13 +12705,11 @@ SISSearchCRT1Rate(ScrnInfoPtr pScrn, DisplayModePtr mode)
    if( (pSiS->ChipType == SIS_730)        &&
        (pSiS->VBFlags2 & VB2_VIDEOBRIDGE) &&
        (pSiS->CurrentLayout.bitsPerPixel == 32) ) {
-#ifdef SISDUALHEAD
       if(pSiS->DualHeadMode) {
          if(pSiS->SecondHead) {
 	    checksis730 = TRUE;
 	 }
       } else
-#endif
       if((!pSiS->UseVESA) && (pSiS->VBFlags & CRT2_ENABLE) && (!pSiS->CRT1off)) {
          checksis730 = TRUE;
       }
@@ -13225,14 +12817,12 @@ SISWaitVBRetrace(ScrnInfoPtr pScrn)
    SISPtr  pSiS = SISPTR(pScrn);
 
    if((pSiS->VGAEngine == SIS_300_VGA) || (pSiS->VGAEngine == SIS_315_VGA)) {
-#ifdef SISDUALHEAD
       if(pSiS->DualHeadMode) {
    	 if(pSiS->SecondHead)
 	    SISWaitRetraceCRT1(pScrn);
          else
 	    SISWaitRetraceCRT2(pScrn);
       } else {
-#endif
 	 if(pSiS->VBFlags & DISPTYPE_DISP1) {
 	    SISWaitRetraceCRT1(pScrn);
 	 }
@@ -13241,9 +12831,7 @@ SISWaitVBRetrace(ScrnInfoPtr pScrn)
 	       SISWaitRetraceCRT2(pScrn);
 	    }
 	 }
-#ifdef SISDUALHEAD
       }
-#endif
    } else {
       SISWaitRetraceCRT1(pScrn);
    }

--- a/src/sis_driver.h
+++ b/src/sis_driver.h
@@ -1549,9 +1549,7 @@ static Bool SISSwitchMode(ScrnInfoPtr arg, DisplayModePtr mode);
 void	    SISAdjustFrame(ScrnInfoPtr arg, int x, int y);
 
 /* Optional functions */
-#ifdef SISDUALHEAD
 static Bool 	  SISSaveScreenDH(ScreenPtr pScreen, int mode);
-#endif
 static void       SISFreeScreen(ScrnInfoPtr arg);
 static ModeStatus SISValidMode(ScrnInfoPtr arg, DisplayModePtr mode,
 				Bool verbose, int flags);

--- a/src/sis_opt.c
+++ b/src/sis_opt.c
@@ -319,7 +319,6 @@ SiS_PrintIlRange(ScrnInfoPtr pScrn, int token, int min, int max, UChar showhex)
 	pSiS->Options[SiS_FIFT(pSiS->Options, token)].name, min, max);
 }
 
-#ifdef SISDUALHEAD
 static void
 SiS_PrintOverruleDHM(ScrnInfoPtr pScrn, int token1, int token2)
 {
@@ -330,7 +329,6 @@ SiS_PrintOverruleDHM(ScrnInfoPtr pScrn, int token1, int token2)
 	pSiS->Options[SiS_FIFT(pSiS->Options, token1)].name,
 	pSiS->Options[SiS_FIFT(pSiS->Options, token2)].name);
 }
-#endif
 
 static Bool
 SiS_StrIsBoolOn(char *strptr)
@@ -776,17 +774,14 @@ SiSOptions(ScrnInfoPtr pScrn)
        }
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        IsDHM = TRUE;
        if(pSiS->SecondHead) IsSecondHead = TRUE;
     }
-#endif
 
     /* MergedFB
      * Enable/disable and configure merged framebuffer mode
      */
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        if(xf86IsOptionSet(pSiS->Options, OPTION_MERGEDFB)) {
 	  xf86DrvMsg(pScrn->scrnIndex, X_WARNING, baddhm,
@@ -797,7 +792,6 @@ SiSOptions(ScrnInfoPtr pScrn)
 	     pSiS->Options[SiS_FIFT(pSiS->Options, OPTION_MERGEDFBAUTO)].name);
        }
     } else
-#endif
     if((pSiS->VGAEngine == SIS_300_VGA) || (pSiS->VGAEngine == SIS_315_VGA)) {
        if((strptr = (char *)xf86GetOptValString(pSiS->Options, OPTION_MERGEDFB))) {
 	  if(SiS_StrIsBoolOn(strptr)) {
@@ -924,7 +918,6 @@ SiSOptions(ScrnInfoPtr pScrn)
     /* Some options can only be specified in the Master Head's Device
      * section. Here we give the user a hint in the log.
      */
-#ifdef SISDUALHEAD
     if((pSiS->DualHeadMode) && (pSiS->SecondHead)) {
        static const char * const mystring = "Option \"%s\" only accepted in CRT2 (Master) Device section\n";
        int i;
@@ -961,7 +954,6 @@ SiSOptions(ScrnInfoPtr pScrn)
        }
 
     } else
-#endif
     {
        if(pSiS->VGAEngine == SIS_315_VGA) {
 
@@ -1003,12 +995,10 @@ SiSOptions(ScrnInfoPtr pScrn)
 	   */
 	  ival = 0;
 	  from = X_DEFAULT;
-#ifdef SISDUALHEAD
 	  if(pSiS->DualHeadMode) {
 	     pSiS->AllowHotkey = 0;
 	     ival = 1;
 	  } else
-#endif
 	  if(xf86GetOptValBool(pSiS->Options, OPTION_ENABLEHOTKEY, &val)) {
 	     pSiS->AllowHotkey = val ? 1 : 0;
 	     from = X_CONFIG;
@@ -1724,7 +1714,6 @@ SiSOptions(ScrnInfoPtr pScrn)
 		   pSiS->CRT2gamma = TRUE;
 		   if(!IsDHM) pSiS->CRT2SepGamma = TRUE;
 		   else {
-#ifdef SISDUALHEAD
 		      pSiS->CRT2SepGamma = FALSE;
 		      xf86DrvMsg(pScrn->scrnIndex, X_INFO,
 				"CRT2Gamma values overrule default and Monitor Gamma\n");
@@ -1733,7 +1722,6 @@ SiSOptions(ScrnInfoPtr pScrn)
 			 pScrn->monitor->gamma.green = pSiS->GammaG2;
 			 pScrn->monitor->gamma.blue = pSiS->GammaB2;
 		      }
-#endif
 		   }
 		}
 	     }
@@ -2121,12 +2109,10 @@ SiSOptions(ScrnInfoPtr pScrn)
 	        if(SiS_EvalOneOrThreeFloats2(pScrn, OPTION_NEWSTOREDBRI2, newbriopt, strptr,
 				&pSiS->NewGammaBriR2, &pSiS->NewGammaBriG2, &pSiS->NewGammaBriB2)) {
 		   if(IsDHM) {
-#ifdef SISDUALHEAD
 		      if(GotNewBri) SiS_PrintOverruleDHM(pScrn, OPTION_NEWSTOREDBRI2, OPTION_NEWSTOREDBRI);
 		      pSiS->NewGammaBriR = pSiS->NewGammaBriR2;
 		      pSiS->NewGammaBriG = pSiS->NewGammaBriG2;
 		      pSiS->NewGammaBriB = pSiS->NewGammaBriB2;
-#endif
 	           } else pSiS->CRT2SepGamma = TRUE;
 	        }
 	        GotNewBri2 = TRUE;
@@ -2138,12 +2124,10 @@ SiSOptions(ScrnInfoPtr pScrn)
 	        if(SiS_EvalOneOrThreeFloats(pScrn, OPTION_STOREDBRI2, briopt, strptr,
 		    &pSiS->GammaBriR2, &pSiS->GammaBriG2, &pSiS->GammaBriB2)) {
 	           if(IsDHM) {
-#ifdef SISDUALHEAD
 		      if(GotOldBri) SiS_PrintOverruleDHM(pScrn, OPTION_STOREDBRI2, OPTION_STOREDBRI);
 		      pSiS->GammaBriR = pSiS->GammaBriR2;
 		      pSiS->GammaBriG = pSiS->GammaBriG2;
 		      pSiS->GammaBriB = pSiS->GammaBriB2;
-#endif
 	           } else pSiS->CRT2SepGamma = TRUE;
 	        }
 	     }

--- a/src/sis_utility.c
+++ b/src/sis_utility.c
@@ -309,9 +309,7 @@ SISSwitchCRT1Status(ScrnInfoPtr pScrn, int onoff, Bool quiet)
     /* Off only if at least one CRT2 device is active */
     if((!onoff) && (!(vbflags & CRT2_ENABLE))) return FALSE;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) return FALSE;
-#endif
 
     /* Can't switch to LCDA if not supported (duh!) */
     if(!(pSiS->SiS_SD_Flags & SiS_SD_SUPPORTLCDA)) {
@@ -407,9 +405,7 @@ SISRedetectCRT2Devices(ScrnInfoPtr pScrn)
        return FALSE;
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) return FALSE;
-#endif
 
     /* Sync the accelerators */
     (*pSiS->SyncAccel)(pScrn);
@@ -462,9 +458,7 @@ SISSwitchCRT2Type(ScrnInfoPtr pScrn, ULong newvbflags, Bool quiet)
     /* Only if there is a video bridge */
     if(!(pSiS->VBFlags2 & VB2_VIDEOBRIDGE)) return FALSE;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) return FALSE;
-#endif
 
 #define SiS_NewVBMask (CRT2_ENABLE|CRT1_LCDA|TV_PAL|TV_NTSC|TV_PALM|TV_PALN|TV_NTSCJ| \
 		       TV_AVIDEO|TV_SVIDEO|TV_SCART|TV_HIVISION|TV_YPBPR|TV_YPBPRALL|\
@@ -616,9 +610,7 @@ SISCheckModeForCRT2Type(ScrnInfoPtr pScrn, DisplayModePtr mode, ULong vbflags, U
 
     mastermode = mode;
 
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead)) {
-#endif
 
        if(vbflags & CRT2_ENABLE) {
 
@@ -649,15 +641,11 @@ SISCheckModeForCRT2Type(ScrnInfoPtr pScrn, DisplayModePtr mode, ULong vbflags, U
 
        }
 
-#ifdef SISDUALHEAD
     }
-#endif
 
     mode = mastermode;
 
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (pSiS->SecondHead)) {
-#endif
 
        if(vbflags & CRT1_LCDA) {
 
@@ -688,9 +676,7 @@ SISCheckModeForCRT2Type(ScrnInfoPtr pScrn, DisplayModePtr mode, ULong vbflags, U
 
        }
 
-#ifdef SISDUALHEAD
     }
-#endif
 
     return result;
 }
@@ -818,9 +804,7 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 {
    ScrnInfoPtr pScrn = xf86ScreenToScrn(screenInfo.screens[sdcbuf->screen]);
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
    SISPortPrivPtr pPriv = NULL;
    ULong j;
 
@@ -928,30 +912,22 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
       break;
 
    case SDC_CMD_SETVBFLAGS:
-#ifdef SISDUALHEAD
       if(!pSiS->DualHeadMode) {
-#endif
 	 if(pSiS->xv_sisdirectunlocked) {
 	    SISSwitchCRT2Type(pScrn, (ULong)sdcbuf->sdc_parm[0], pSiS->SCLogQuiet);
 	    if(pPriv) SISUpdateVideoParms(pSiS, pPriv);
 	 } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
-#ifdef SISDUALHEAD
       } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
-#endif
       break;
 
    case SDC_CMD_NEWSETVBFLAGS:
-#ifdef SISDUALHEAD
       if(!pSiS->DualHeadMode) {
-#endif
 	 if(pSiS->xv_sisdirectunlocked) {
 	    SISSwitchOutputType(pScrn, (ULong)sdcbuf->sdc_parm[0], (ULong)sdcbuf->sdc_parm[1],
 	    		(ULong)sdcbuf->sdc_parm[2], pSiS->SCLogQuiet);
 	    if(pPriv) SISUpdateVideoParms(pSiS, pPriv);
 	 } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
-#ifdef SISDUALHEAD
       } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
-#endif
       break;
 
    case SDC_CMD_GETDETECTEDDEVICES:
@@ -959,15 +935,11 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
       break;
 
    case SDC_CMD_REDETECTCRT2DEVICES:
-#ifdef SISDUALHEAD
       if(!pSiS->DualHeadMode) {
-#endif
 	 if(pSiS->xv_sisdirectunlocked) {
 	    SISRedetectCRT2Devices(pScrn);
 	 } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
-#ifdef SISDUALHEAD
       } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
-#endif
       break;
 
    case SDC_CMD_GETCRT1STATUS:
@@ -975,16 +947,12 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
       break;
 
    case SDC_CMD_SETCRT1STATUS:
-#ifdef SISDUALHEAD
       if(!pSiS->DualHeadMode) {
-#endif
 	 if(pSiS->xv_sisdirectunlocked) {
 	    SISSwitchCRT1Status(pScrn, (ULong)sdcbuf->sdc_parm[0], pSiS->SCLogQuiet);
 	    if(pPriv) SISUpdateVideoParms(pSiS, pPriv);
 	 } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
-#ifdef SISDUALHEAD
       } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
-#endif
       break;
 
    case SDC_CMD_GETSDFLAGS:
@@ -1151,18 +1119,14 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
    case SDC_CMD_GETGAMMASTATUS:
       {
          int i = 0;
-#ifdef SISDUALHEAD
 	 if(pSiS->DualHeadMode) {
 	    if(pSiSEnt->CRT1gamma) i |= 0x01;
 	    if(pSiSEnt->CRT2gamma) i |= 0x02;
 	 } else {
-#endif
 	    if(pSiS->CRT1gamma)    i |= 0x01;
 	    if(pSiS->CRT2gamma)    i |= 0x02;
 	    if(pSiS->CRT2SepGamma) i |= 0x08;
-#ifdef SISDUALHEAD
 	 }
-#endif
 	 if(pSiS->XvGamma) i |= 0x04;
          sdcbuf->sdc_result[0] = i;
       }
@@ -1175,12 +1139,10 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 	 Bool backup2 = pSiS->CRT2SepGamma;
 	 pSiS->CRT1gamma = (value & 0x01) ? TRUE : FALSE;
 	 pSiS->CRT2gamma = (value & 0x02) ? TRUE : FALSE;
-#ifdef SISDUALHEAD
 	 if(pSiS->DualHeadMode) {
 	    pSiSEnt->CRT1gamma = pSiS->CRT1gamma;
 	    pSiSEnt->CRT2gamma = pSiS->CRT2gamma;
 	 }
-#endif
 	 if(pSiS->SiS_SD_Flags & SiS_SD_SUPPORTSGRCRT2) {
 	    pSiS->CRT2SepGamma = (value & 0x08) ? TRUE : FALSE;
 	    if(pSiS->CRT2SepGamma != backup2) {
@@ -1297,21 +1259,18 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
       break;
 
    case SDC_CMD_GETGAMMABRIGHTNESS2: /* xv_BRx2, xv_PBx2 */
-#ifdef SISDUALHEAD
       if(pSiS->DualHeadMode) {
          sdcbuf->sdc_result[0] = pSiSEnt->GammaBriR;
 	 sdcbuf->sdc_result[1] = pSiSEnt->GammaBriG;
 	 sdcbuf->sdc_result[2] = pSiSEnt->GammaBriB;
 	 break;
       }
-#endif
       sdcbuf->sdc_result[0] = pSiS->GammaBriR;
       sdcbuf->sdc_result[1] = pSiS->GammaBriG;
       sdcbuf->sdc_result[2] = pSiS->GammaBriB;
       break;
 
    case SDC_CMD_GETNEWGAMMABRICON2: /* no xv pendant */
-#ifdef SISDUALHEAD
       if(pSiS->DualHeadMode) {
          sdcbuf->sdc_result[0] = (CARD32)(((int)(pSiSEnt->NewGammaBriR * 1000.0)) + 1000);
 	 sdcbuf->sdc_result[1] = (CARD32)(((int)(pSiSEnt->NewGammaBriG * 1000.0)) + 1000);
@@ -1321,7 +1280,6 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 	 sdcbuf->sdc_result[5] = (CARD32)(((int)(pSiSEnt->NewGammaConB * 1000.0)) + 1000);
 	 break;
       }
-#endif
       sdcbuf->sdc_result[0] = (CARD32)(((int)(pSiS->NewGammaBriR * 1000.0)) + 1000);
       sdcbuf->sdc_result[1] = (CARD32)(((int)(pSiS->NewGammaBriG * 1000.0)) + 1000);
       sdcbuf->sdc_result[2] = (CARD32)(((int)(pSiS->NewGammaBriB * 1000.0)) + 1000);
@@ -1337,7 +1295,6 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 	 sdcbuf->sdc_result_header = SDC_RESULT_INVAL;
       } else if(pSiS->xv_sisdirectunlocked) {
          pSiS->SiS_SD3_Flags |= SiS_SD3_OLDGAMMAINUSE;
-#ifdef SISDUALHEAD
 	 if(pSiS->DualHeadMode) {
 	    pSiSEnt->GammaBriR = sdcbuf->sdc_parm[0];
 	    pSiSEnt->GammaBriG = sdcbuf->sdc_parm[1];
@@ -1345,7 +1302,6 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 	    pSiSEnt->NewGammaBriR = pSiSEnt->NewGammaBriG = pSiSEnt->NewGammaBriB = 0.0;
 	    pSiSEnt->NewGammaConR = pSiSEnt->NewGammaConG = pSiSEnt->NewGammaConB = 0.0;
 	 }
-#endif
       } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
       break;
 
@@ -1356,7 +1312,6 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 	 sdcbuf->sdc_result_header = SDC_RESULT_INVAL;
       } else if(pSiS->xv_sisdirectunlocked) {
          pSiS->SiS_SD3_Flags &= ~SiS_SD3_OLDGAMMAINUSE;
-#ifdef SISDUALHEAD
 	 if(pSiS->DualHeadMode) {
 	    pSiSEnt->NewGammaBriR = ((float)((int)sdcbuf->sdc_parm[0] - 1000)) / 1000.0;
 	    pSiSEnt->NewGammaBriG = ((float)((int)sdcbuf->sdc_parm[1] - 1000)) / 1000.0;
@@ -1366,7 +1321,6 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 	    pSiSEnt->NewGammaConB = ((float)((int)sdcbuf->sdc_parm[5] - 1000)) / 1000.0;
 	    pSiSEnt->GammaBriR = pSiSEnt->GammaBriG = pSiSEnt->GammaBriB = 1000;
 	 }
-#endif
       } else sdcbuf->sdc_result_header = SDC_RESULT_NOPERM;
       break;
 
@@ -1536,11 +1490,9 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
       {
          SISPtr	mypSiS = pSiS;
 	 sdcbuf->sdc_result[0] = 0;
-#ifdef SISDUALHEAD
 	 if(pSiS->DualHeadMode) {
 	    if(pSiSEnt->pScrn_2) mypSiS = SISPTR(pSiSEnt->pScrn_2);
 	 }
-#endif
 	 sisutil_prepare_string(sdcbuf, mypSiS->devsectname);
       }
       break;
@@ -1549,11 +1501,9 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
       {
          ScrnInfoPtr mypScrn = pScrn;
          sdcbuf->sdc_result[0] = 0;
-#ifdef SISDUALHEAD
 	 if(pSiS->DualHeadMode) {
 	    if(pSiSEnt->pScrn_2) mypScrn = pSiSEnt->pScrn_2;
 	 }
-#endif
          if(mypScrn->monitor) {
             sisutil_prepare_string(sdcbuf, mypScrn->monitor->id);
          }
@@ -1562,19 +1512,16 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
 
    case SDC_CMD_GETDEVICENAME2:		/* In DualHead mode, this returns CRT2 data */
       sdcbuf->sdc_result[0] = 0;
-#ifdef SISDUALHEAD
       if(pSiS->DualHeadMode) {
          if(pSiSEnt->pScrn_1) {
 	    sisutil_prepare_string(sdcbuf, SISPTR(pSiSEnt->pScrn_1)->devsectname);
 	 }
       } else
-#endif
 	 sdcbuf->sdc_result_header = SDC_RESULT_INVAL;
       break;
 
    case SDC_CMD_GETMONITORNAME2:	/* In DualHead mode, this returns CRT2 data */
       sdcbuf->sdc_result[0] = 0;
-#ifdef SISDUALHEAD
       if(pSiS->DualHeadMode) {
          if(pSiSEnt->pScrn_1) {
 	    if(pSiSEnt->pScrn_1->monitor) {
@@ -1582,7 +1529,6 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
             }
 	 }
       } else
-#endif
 	 sdcbuf->sdc_result_header = SDC_RESULT_INVAL;
       break;
 
@@ -1723,20 +1669,16 @@ SiSHandleSiSDirectCommand(xSiSCtrlCommandReply *sdcbuf)
       if((pPriv) && (pSiS->VGAEngine == SIS_315_VGA)) {
          if(pPriv->AllowSwitchCRT) {
 	    pPriv->crtnum = sdcbuf->sdc_parm[0] ? 1 : 0;
-#ifdef SISDUALHEAD
             if(pPriv->dualHeadMode) pSiSEnt->curxvcrtnum = pPriv->crtnum;
-#endif
 	 }
       } else sdcbuf->sdc_result_header = SDC_RESULT_INVAL;
       break;
 
    case SDC_CMD_GETXVSWITCHCRT:
       if((pPriv) && (pSiS->VGAEngine == SIS_315_VGA)) {
-#ifdef SISDUALHEAD
          if(pPriv->dualHeadMode)
             sdcbuf->sdc_result[0] = pSiSEnt->curxvcrtnum;
          else
-#endif
             sdcbuf->sdc_result[0] = pPriv->crtnum;
       } else sdcbuf->sdc_result_header = SDC_RESULT_INVAL;
       break;

--- a/src/sis_vb.c
+++ b/src/sis_vb.c
@@ -237,13 +237,11 @@ void SISCRT1PreInit(ScrnInfoPtr pScrn)
        return;
     }
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) {
        pSiS->CRT1Detected = TRUE;
        pSiS->CRT1off = 0;
        return;
     }
-#endif
 
     if((pSiS->MergedFB) && (!(pSiS->MergedFBAuto))) {
        pSiS->CRT1Detected = TRUE;
@@ -324,9 +322,7 @@ void SISLCDPreInit(ScrnInfoPtr pScrn, Bool quiet)
      * and buggy BIOS method.
      *
      */
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead)) {
-#endif
        if((pSiS->VGAEngine == SIS_315_VGA) &&
 	  (pSiS->VBFlags2 & VB2_SISTMDSBRIDGE) &&
 	  (!(pSiS->VBFlags2 & VB2_30xBDH)) &&
@@ -364,9 +360,7 @@ void SISLCDPreInit(ScrnInfoPtr pScrn, Bool quiet)
 	  }
 
        }
-#ifdef SISDUALHEAD
     }
-#endif
 
     if(pSiS->VBFlags & CRT2_LCD) {
        inSISIDXREG(SISCR, 0x36, CR36);
@@ -702,9 +696,7 @@ void SISCRT2PreInit(ScrnInfoPtr pScrn, Bool quiet)
     /* See the comment in initextx.c/SiS_SenseVGA2DDC() */
     if(pSiS->SiS_Pr->DDCPortMixup) return;
 
-#ifdef SISDUALHEAD
     if((!pSiS->DualHeadMode) || (!pSiS->SecondHead)) {
-#endif
 
        if(pSiS->forcecrt2redetection) {
           pSiS->VBFlags &= ~CRT2_VGA;
@@ -740,9 +732,7 @@ void SISCRT2PreInit(ScrnInfoPtr pScrn, Bool quiet)
 	     }
           }
        }
-#ifdef SISDUALHEAD
     }
-#endif
 }
 
 static int
@@ -1132,9 +1122,7 @@ Bool SISRedetectCRT2Type(ScrnInfoPtr pScrn)
     Bool   backup1 = pSiS->forcecrt2redetection;
     Bool   backup2 = pSiS->nocrt2ddcdetection;
 
-#ifdef SISDUALHEAD
     if(pSiS->DualHeadMode) return FALSE;
-#endif
 
     pSiS->VBFlags &= ~(CRT2_DEFAULT   |
 		       CRT2_ENABLE    |

--- a/src/sis_video.c
+++ b/src/sis_video.c
@@ -264,9 +264,7 @@ SiSUpdateXvGamma(SISPtr pSiS, SISPortPrivPtr pPriv)
     if(!pSiS->XvGamma) return;
     if(!(pSiS->MiscFlags & MISC_CRT1OVERLAYGAMMA)) return;
 
-#ifdef SISDUALHEAD
     if((pPriv->dualHeadMode) && (!pSiS->SecondHead)) return;
-#endif
 
     if(!(sr7 & 0x04)) return;
 
@@ -355,9 +353,7 @@ void
 SISSetPortDefaults(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 {
     SISPtr    pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;;
-#endif
 
     pPriv->colorKey    = pSiS->colorKey = 0x000101fe;
     pPriv->brightness  = pSiS->XvDefBri;
@@ -374,14 +370,12 @@ SISSetPortDefaults(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
     pPriv->chromamin       = pSiS->XvChromaMin;
     pPriv->chromamax       = pSiS->XvChromaMax;
     if(pPriv->dualHeadMode) {
-#ifdef SISDUALHEAD
        if(!pSiS->SecondHead) {
           pPriv->tvxpos      = pSiS->tvxpos;
           pPriv->tvypos      = pSiS->tvypos;
 	  pPriv->updatetvxpos = TRUE;
           pPriv->updatetvypos = TRUE;
        }
-#endif
     } else {
        pPriv->tvxpos      = pSiS->tvxpos;
        pPriv->tvypos      = pSiS->tvypos;
@@ -389,11 +383,9 @@ SISSetPortDefaults(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
        pPriv->updatetvypos = TRUE;
     }
     if(pPriv->dualHeadMode) {
-#ifdef SISDUALHEAD
        pPriv->crtnum =
 	  pSiSEnt->curxvcrtnum =
 	     pSiSEnt->XvOnCRT2 ? 1 : 0;
-#endif
     } else
        pPriv->crtnum = pSiS->XvOnCRT2 ? 1 : 0;
 
@@ -624,7 +616,6 @@ set_dispmode(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
        else
 	  pPriv->displayMode = DISPMODE_SINGLE1;    /* CRT1 only */
     } else {
-#ifdef SISDUALHEAD
        if(pSiS->DualHeadMode) {
 	  pPriv->dualHeadMode = TRUE;
 	  if(pSiS->SecondHead)
@@ -632,7 +623,6 @@ set_dispmode(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	  else
 	     pPriv->displayMode = DISPMODE_SINGLE2; /* CRT2 only */
        } else
-#endif
        if(pSiS->VBFlags & DISPTYPE_DISP1) {
 	  pPriv->displayMode = DISPMODE_SINGLE1;    /* CRT1 only */
        } else {
@@ -645,12 +635,10 @@ static void
 set_disptype_regs(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 {
     SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
     SISEntPtr pSiSEnt = pSiS->entityPrivate;
     int crtnum = 0;
 
     if(pPriv->dualHeadMode) crtnum = pSiSEnt->curxvcrtnum;
-#endif
 
     /*
      *     SR06[7:6]
@@ -690,14 +678,10 @@ set_disptype_regs(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 		 setsrregmask(pSiS, 0x32, 0x00, 0xc0);
 	      }
 	  } else {
-#ifdef SISDUALHEAD
 	      if((!pPriv->dualHeadMode) || (crtnum == 0)) {
-#endif
 		 setsrregmask(pSiS, 0x06, 0x00, 0xc0);  /* only overlay -> CRT1 */
 		 setsrregmask(pSiS, 0x32, 0x00, 0xc0);
-#ifdef SISDUALHEAD
 	      }
-#endif
 	  }
 	  break;
 
@@ -711,9 +695,7 @@ set_disptype_regs(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 		 setsrregmask(pSiS, 0x32, 0xc0, 0xc0);  /* (although both clocks for CRT2!) */
 	      }
 	  } else {
-#ifdef SISDUALHEAD
 	      if((!pPriv->dualHeadMode) || (crtnum == 1)) {
-#endif
 		 if(pSiS->MiscFlags & MISC_SIS760ONEOVERLAY) {
 		    setsrregmask(pSiS, 0x06, 0x40, 0xc0);  /* overlay 0 -> CRT2 */
 		    setsrregmask(pSiS, 0x32, 0xc0, 0xc0);  /* (although both clocks for CRT2!) */
@@ -721,9 +703,7 @@ set_disptype_regs(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 		    setsrregmask(pSiS, 0x06, 0x40, 0xc0);  /* only overlay -> CRT2 */
 		    setsrregmask(pSiS, 0x32, 0x40, 0xc0);
 		 }
-#ifdef SISDUALHEAD
               }
-#endif
 	  }
 	  break;
 
@@ -800,11 +780,9 @@ set_maxencoding(SISPtr pSiS, SISPortPrivPtr pPriv)
           half = 1920; /* ? */
        }
        if(pPriv->hasTwoOverlays) {
-#ifdef SISDUALHEAD
           if(pSiS->DualHeadMode) {
 	     DummyEncoding.width = half;
           } else
-#endif
           if(pSiS->MergedFB) {
 	     DummyEncoding.width = half;
           } else
@@ -1050,9 +1028,7 @@ SISSetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
 {
   SISPortPrivPtr pPriv = (SISPortPrivPtr)data;
   SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
   SISEntPtr pSiSEnt = pSiS->entityPrivate;;
-#endif
 
   if(attribute == pSiS->xvBrightness) {
      if((value < -128) || (value > 127))
@@ -1088,9 +1064,7 @@ SISSetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
         pPriv->updatetvxpos = FALSE;
      } else {
         pSiS->tvxpos = pPriv->tvxpos;
-#ifdef SISDUALHEAD
         if(pPriv->dualHeadMode) pSiSEnt->tvxpos = pPriv->tvxpos;
-#endif
         pPriv->updatetvxpos = TRUE;
      }
   } else if(attribute == pSiS->xvTVYPosition) {
@@ -1101,9 +1075,7 @@ SISSetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
         pPriv->updatetvypos = FALSE;
      } else {
         pSiS->tvypos = pPriv->tvypos;
-#ifdef SISDUALHEAD
         if(pPriv->dualHeadMode) pSiSEnt->tvypos = pPriv->tvypos;
-#endif
         pPriv->updatetvypos = TRUE;
      }
   } else if(attribute == pSiS->xvDisableColorkey) {
@@ -1156,9 +1128,7 @@ SISSetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
            if((value < 0) || (value > 1))
               return BadValue;
 	   pPriv->crtnum = value;
-#ifdef SISDUALHEAD
            if(pPriv->dualHeadMode) pSiSEnt->curxvcrtnum = value;
-#endif
         }
      } else return BadMatch;
   } else {
@@ -1177,9 +1147,7 @@ SISGetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
 {
   SISPortPrivPtr pPriv = (SISPortPrivPtr)data;
   SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
   SISEntPtr pSiSEnt = pSiS->entityPrivate;;
-#endif
 
   if(attribute == pSiS->xvBrightness) {
      *value = pPriv->brightness;
@@ -1231,11 +1199,9 @@ SISGetPortAttribute(ScrnInfoPtr pScrn, Atom attribute,
      } else return BadMatch;
   } else if(attribute == pSiS->xvSwitchCRT) {
      if(pSiS->VGAEngine == SIS_315_VGA) {
-#ifdef SISDUALHEAD
         if(pPriv->dualHeadMode)
            *value = pSiSEnt->curxvcrtnum;
         else
-#endif
            *value = pPriv->crtnum;
      } else return BadMatch;
   } else {
@@ -2394,12 +2360,10 @@ close_overlay(SISPtr pSiS, SISPortPrivPtr pPriv)
 
      } else if(pPriv->displayMode == DISPMODE_SINGLE2) {
 
-#ifdef SISDUALHEAD
 	if(pPriv->dualHeadMode) {
 	   /* Check if overlay already grabbed by other head */
 	   if(!(getsrreg(pSiS, 0x06) & 0x40)) return;
 	}
-#endif
 	setvideoregmask(pSiS, Index_VI_Control_Misc2, 0x00, 0x01);
 
      }
@@ -2422,14 +2386,12 @@ close_overlay(SISPtr pSiS, SISPortPrivPtr pPriv)
      /* CRT1: Always uses overlay 0
       */
 
-#ifdef SISDUALHEAD
      if(pPriv->dualHeadMode) {
 	if(!pPriv->hasTwoOverlays) {
 	   /* Check if overlay already grabbed by other head */
 	   if(getsrreg(pSiS, 0x06) & 0x40) return;
 	}
      }
-#endif
 
      setvideoregmask(pSiS, Index_VI_Control_Misc2, 0x00, 0x05);
      setvideoregmask(pSiS, Index_VI_Control_Misc1, 0x00, 0x01);
@@ -2455,9 +2417,7 @@ static void
 SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 {
    SISPtr pSiS = SISPTR(pScrn);
-#ifdef SISDUALHEAD
    SISEntPtr pSiSEnt = pSiS->entityPrivate;
-#endif
    short  srcPitch = pPriv->srcPitch;
    short  height = pPriv->height;
    UShort screenwidth;
@@ -2474,7 +2434,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
    set_hastwooverlays(pSiS, pPriv);
 
    pPriv->NoOverlay = FALSE;
-#ifdef SISDUALHEAD
    if(pPriv->dualHeadMode) {
       if(!pPriv->hasTwoOverlays) {
 	 if(pSiS->SecondHead) {
@@ -2496,7 +2455,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
 	 }
       }
    }
-#endif
 
    /* setup dispmode (MIRROR, SINGLEx) */
    set_dispmode(pScrn, pPriv);
@@ -2912,7 +2870,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
       calc_line_buf_size_2(&overlay, pPriv);
 
    if(pPriv->dualHeadMode) {
-#ifdef SISDUALHEAD
       if(!pSiS->SecondHead) {
          if(pPriv->updatetvxpos) {
             SiS_SetTVxposoffset(pScrn, pPriv->tvxpos);
@@ -2923,7 +2880,6 @@ SISDisplayVideo(ScrnInfoPtr pScrn, SISPortPrivPtr pPriv)
             pPriv->updatetvypos = FALSE;
          }
       }
-#endif
    } else {
       if(pPriv->updatetvxpos) {
          SiS_SetTVxposoffset(pScrn, pPriv->tvxpos);


### PR DESCRIPTION
It's always enabled, so no need for #ifdef's