### PR TITLE
sis_driver.c: drop including edid.h

### DIFF
--- a/src/sis_driver.c
+++ b/src/sis_driver.c
@@ -54,7 +54,6 @@
 #include "fb.h"
 #include "micmap.h"
 #include "mipointer.h"
-#include "edid.h"
 
 #define SIS_NEED_inSISREG
 #define SIS_NEED_inSISIDXREG


### PR DESCRIPTION
not needed anymore.